### PR TITLE
Non 200 success

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -537,7 +537,7 @@ class Dropzone extends Em
       @errorProcessing file, xhr.responseText || "Server responded with #{xhr.status} code."
 
     xhr.onload = (e) =>
-      if xhr.status isnt 200
+      if xhr.status < 200 or xhr.status >= 300
         handleError()
       else
         @emit "uploadprogress", file, 100


### PR DESCRIPTION
When uploading a file with a POST request, it is acceptable to respond with a 201 created status code (as is the case with Amazon S3).  Dropzone was treating a 201 as an error, this commit treats all 2XX status codes as a success.

References:
- http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
