### PR TITLE
Fixed equality check of tagName

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -588,7 +588,7 @@ class Dropzone extends Em
     formData.append key, value for key, value of @options.params if @options.params
 
     # Take care of other input elements
-    if @element.tagName = "FORM"
+    if @element.tagName == "FORM"
       for input in @element.querySelectorAll "input, textarea, select, button"
         inputName = input.getAttribute "name"
         inputType = input.getAttribute "type"


### PR DESCRIPTION
It looks like assignment was used instead of an equality check when checking if an element is a form.
