### PR TITLE
Make dropzone message clickable

### DIFF
--- a/downloads/css/stylus/basic.styl
+++ b/downloads/css/stylus/basic.styl
@@ -35,7 +35,7 @@
 
   &.clickable
     cursor pointer
-    .message
+    .message, .message span
       cursor pointer
     *
       cursor default

--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -348,7 +348,7 @@ class Dropzone extends Em
       "click": (evt) =>
         return unless @options.clickable
         # Only the actual dropzone or the message element should trigger file selection
-        if evt.target == @element or evt.target == @element.querySelector ".message"
+        if evt.target == @element or evt.target == @element.querySelector ".message" or evt.target == @element.querySelector ".message span"
           @hiddenFileInput.click() # Forward the click
 
 


### PR DESCRIPTION
In the current build of Dropzone, you can click anywhere in the drop zone to bring up the browse dialog _except_ the "Drop files here or click" message, which is a little odd. This patch should fix that. 

I wasn't able to test the patch as-is, because I couldn't build properly with grunt (stylus complained that it couldn't find nib, and the built JS file didn't seem to work). I did test basically the same patch in (a slightly older version of) the checked-in JS file and basic.css, and it worked. So, hopefully it will work for you :)
