### PR TITLE
New Dropzone.options.thumbnailKeepAspectRatio option

### DIFF
--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -60,6 +60,7 @@
       maxThumbnailFilesize: 2,
       thumbnailWidth: 100,
       thumbnailHeight: 100,
+      thumbnailKeepAspectRatio: false,
       params: {},
       clickable: true,
       enqueueForUpload: true,
@@ -550,13 +551,39 @@
           srcY = 0;
           srcWidth = img.width;
           srcHeight = img.height;
-          canvas.width = _this.options.thumbnailWidth;
-          canvas.height = _this.options.thumbnailHeight;
+          srcRatio = img.width / img.height;
+          
+          if (_this.options.thumbnailKeepAspectRatio == true) {
+            var srcThumbnailLongestSide = Math.max(_this.options.thumbnailWidth,_this.options.thumbnailHeight);
+            var srcLongestSide = Math.max(img.width,img.height);
+            var srcInverseRatio = img.height / img.width;
+
+            if (srcWidth == srcLongestSide) {
+              if (_this.options.thumbnailWidth == srcThumbnailLongestSide) {
+    	          canvas.width = _this.options.thumbnailWidth;
+    	          canvas.height = _this.options.thumbnailWidth*srcInverseRatio;
+              } else if (_this.options.thumbnailHeight == srcThumbnailLongestSide) {
+    	          canvas.width = _this.options.thumbnailHeight;
+    	          canvas.height = _this.options.thumbnailHeight*srcInverseRatio;
+              }
+            } else if (srcHeight == srcLongestSide) {
+              if (_this.options.thumbnailWidth == srcThumbnailLongestSide) {
+    	          canvas.width = _this.options.thumbnailWidth*srcRatio;
+    	          canvas.height = _this.options.thumbnailWidth;
+              } else if (_this.options.thumbnailHeight == srcThumbnailLongestSide) {
+    	          canvas.width = _this.options.thumbnailHeight*srcRatio;
+    	          canvas.height = _this.options.thumbnailHeight;
+              }
+            }
+          } else {
+            canvas.width = _this.options.thumbnailWidth;
+            canvas.height = _this.options.thumbnailHeight;
+          }
+          
           trgX = 0;
           trgY = 0;
           trgWidth = canvas.width;
           trgHeight = canvas.height;
-          srcRatio = img.width / img.height;
           trgRatio = canvas.width / canvas.height;
           if (img.height < canvas.height || img.width < canvas.width) {
             trgHeight = srcHeight;


### PR DESCRIPTION
This pull implements a new boolean `Dropzone.options.thumbnailKeepAspectRatio` option to allow thumbs keep their original aspect ratio based `thumbnailWidth` and `thumbnailHeight` values. 

To make horizontal and vertical previews reasonable similar it considers the longer thumbnail value to use on its longest side.

This also requires to remove fixed styling and remove `position: absolute` from `.details img`.
