### PR TITLE
Added possibility to use xhr object with credentials

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -670,6 +670,9 @@ class Dropzone extends Em
   uploadFile: (file) ->
     xhr = new XMLHttpRequest()
 
+    if @options.withCredentials
+      xhr.withCredentials = true
+
     xhr.open @options.method, @options.url, true
 
 
@@ -760,7 +763,7 @@ class Dropzone extends Em
 
 
 
-Dropzone.version = "3.2.0"
+Dropzone.version = "3.2.1-dev"
 
 
 # This is a map of options for your different dropzones. Add configurations


### PR DESCRIPTION
When there's a need to pass information about credentials in headers (e.g. cookie), "withCredentials" needs to be set to "true" on the xhr object.
