### PR TITLE
Added possibility to use xhr object with credentials:

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -670,6 +670,9 @@ class Dropzone extends Em
   uploadFile: (file) ->
     xhr = new XMLHttpRequest()
 
+    if @options.withCredentials
+      xhr.withCredentials = true
+
     xhr.open @options.method, @options.url, true
 
 


### PR DESCRIPTION
When there's a need to pass information about credentials in headers (e.g. cookie), "withCredentials" needs to be set to "true" on the xhr object.
