### PR TITLE
.tagName property returns lowercase in chrome browser.

### DIFF
--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -269,7 +269,7 @@
       var eventName, noPropagation, setupHiddenFileInput, _i, _len, _ref, _ref1,
         _this = this;
 
-      if (this.element.tagName === "form") {
+      if (this.element.nodeName === "FORM") {
         this.element.setAttribute("enctype", "multipart/form-data");
       }
       if (this.element.classList.contains("dropzone") && !this.element.querySelector("[data-dz-message]")) {
@@ -398,7 +398,7 @@
       }
       fieldsString += "<input type=\"file\" name=\"" + this.options.paramName + "[]\" multiple=\"multiple\" /><button type=\"submit\">Upload!</button></div>";
       fields = Dropzone.createElement(fieldsString);
-      if (this.element.tagName !== "FORM") {
+      if (this.element.nodeName !== "FORM") {
         form = Dropzone.createElement("<form action=\"" + this.options.url + "\" enctype=\"multipart/form-data\" method=\"" + this.options.method + "\"></form>");
         form.appendChild(fields);
       } else {
@@ -710,7 +710,7 @@
           formData.append(key, value);
         }
       }
-      if (this.element.tagName === "FORM") {
+      if (this.element.nodeName === "FORM") {
         _ref2 = this.element.querySelectorAll("input, textarea, select, button");
         for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
           input = _ref2[_i];


### PR DESCRIPTION
.tagName property returns lowercase in chrome browser.
Therefore, it's better to use .nodeName property which always returns uppercase.

.nodeName Case Sensitivity
http://ejohn.org/blog/nodename-case-sensitivity/
