### PR TITLE
Allow custom HTTP headers on file upload

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -312,6 +312,12 @@ class Dropzone extends Em
                       </div>
                       """
 
+  # global utility
+  extend = (target, objects...) ->
+    for object in objects
+      target[key] = val for key, val of object
+    target
+
   constructor: (@element, options) ->
     # For backwards compatibility since the version was in the prototype previously
     @version = Dropzone.version
@@ -340,13 +346,7 @@ class Dropzone extends Em
 
     elementOptions = Dropzone.optionsForElement(@element) ? { }
 
-    extend = (target, objects...) ->
-      for object in objects
-        target[key] = val for key, val of object
-      target
-
     @options = extend { }, @defaultOptions, elementOptions, options ? { }
-
 
     @options.url = @element.action unless @options.url?
 
@@ -743,11 +743,17 @@ class Dropzone extends Em
       progress = 100 * e.loaded / e.total
       @emit "uploadprogress", file, progress, e.loaded
 
-    xhr.setRequestHeader "Accept", "application/json"
-    xhr.setRequestHeader "Cache-Control", "no-cache"
-    xhr.setRequestHeader "X-Requested-With", "XMLHttpRequest"
-    xhr.setRequestHeader "X-File-Name", file.name
+    headers =
+      "Accept":"application/json",
+      "Cache-Control": "no-cache",
+      "X-Requested-With": "XMLHttpRequest",
+      "X-File-Name": file.name
 
+    if this.options.headers
+      extend headers, this.options.headers
+
+    for header, name of headers
+      xhr.setRequestHeader header, name
 
     formData = new FormData()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -653,6 +653,11 @@ describe "Dropzone", ->
           requests.length.should.eql 2
           requests[1].withCredentials.should.eql yes
 
+        it "should correctly override headers on the xhr object", ->
+          dropzone.options.headers = {"Foo-Header": "foobar"}
+          dropzone.uploadFile mockFile
+          requests[0].requestHeaders["Foo-Header"].should.eql 'foobar'
+
 
       describe "should properly set status of file", ->
         it "should correctly set `withCredentials` on the xhr object", ->


### PR DESCRIPTION
This is a feature we needed for a project I am working on in order to integrate with an existing authentication scheme.  The change is relatively simple, so I hope you do not object to the fact that I didn't create a ticket first.

Let me know if I should change anything about the structure/formatting of the change.  Would you prefer me to update the readme file with this new feature?

Also, one suggestion: your contributing documentation is great, except it doesn't mention the component dependency.  It would be helpful to include it along with the directive to run `npm install`.  Let me know if you would like me include that update with this pull request.
