### PR TITLE
Issue74: support drag and drop of folder

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -643,7 +643,7 @@ class Dropzone extends Em
         else if entry.isDirectory
           @addDirectory entry, entry.name
       else
-        @addFile item.getAsEntry()
+        @addFile item.getAsFile()
     return
 
   # If `done()` is called without argument the file is accepted


### PR DESCRIPTION
- I implemented folder upload for my project and decided to contribute it back to dropzone.js
- It's tested on Chrome.
  - I believe Chrome is the only browser that supports folder drag & drop.
  - This feature was added to Chrome 21: http://updates.html5rocks.com/2012/07/Drag-and-drop-a-folder-onto-Chrome-now-available
