### PR TITLE
Destroy should remove "dropzone" property from element

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -525,6 +525,7 @@ class Dropzone extends Em
     if @hiddenFileInput?.parentNode
       @hiddenFileInput.parentNode.removeChild @hiddenFileInput 
       @hiddenFileInput = null
+    delete @element.dropzone
 
 
   updateTotalUploadProgress: ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -536,7 +536,11 @@ describe "Dropzone", ->
           dropzone.destroy()
 
           dropzone.disable.callCount.should.equal 1
+          element.should.not.have.property "dropzone"
 
+      it "should be able to create instance of dropzone on the same element after destroy", ->
+          dropzone.destroy()
+          ( -> new Dropzone element, maxFilesize: 4, url: "url", acceptedMimeTypes: "audio/*,image/png", uploadprogress: -> ).should.not.throw( Error )
 
 
     describe ".filesize()", ->


### PR DESCRIPTION
If there's a need to destroy dropzone instance, and recreate it later, exception happens. Here are the tests & fix for that case.
