### PR TITLE
Calls _updateMaxFilesReachedClass after file.accepted has been set

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -299,8 +299,6 @@ class Dropzone extends Em
 
         file.previewElement.appendChild file._removeLink
 
-      @_updateMaxFilesReachedClass()
-
     # Called whenever a file is removed.
     removedfile: (file) ->
       file.previewElement?.parentNode.removeChild file.previewElement
@@ -744,6 +742,8 @@ class Dropzone extends Em
         @_errorProcessing [ file ], error # Will set the file.status
       else
         @enqueueFile file # Will set .accepted = true
+      @_updateMaxFilesReachedClass()
+
 
   # Wrapper for enqueuFile
   enqueueFiles: (files) -> @enqueueFile file for file in files; null


### PR DESCRIPTION
The method `_updateMaxFilesReachedClass` is called before the property `accepted` is set on the file,
which makes update the CSS class to be set only on maxFiles + 1.

This is what the PR focuses on: make sure that the file has been accepted/rejected **before** the CSS class is toggled.
