### PR TITLE
More flexible previewTemplate (optional fields)

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -281,8 +281,8 @@ class Dropzone extends Em
       file.previewTemplate = file.previewElement # Backwards compatibility
 
       @previewsContainer.appendChild file.previewElement
-      file.previewElement.querySelector("[data-dz-name]").textContent = file.name
-      file.previewElement.querySelector("[data-dz-size]").innerHTML = @filesize file.size
+      node.textContent = file.name for node in file.previewElement.querySelectorAll("[data-dz-name]")
+      node.innerHTML = @filesize file.size for node in file.previewElement.querySelectorAll("[data-dz-size]")
 
       if @options.addRemoveLinks
         file._removeLink = Dropzone.createElement """<a class="dz-remove" href="javascript:undefined;">#{@options.dictRemoveFile}</a>"""
@@ -311,16 +311,16 @@ class Dropzone extends Em
     thumbnail: (file, dataUrl) ->
       file.previewElement.classList.remove "dz-file-preview"
       file.previewElement.classList.add "dz-image-preview"
-      thumbnailElement = file.previewElement.querySelector("[data-dz-thumbnail]")
-      thumbnailElement.alt = file.name
-      thumbnailElement.src = dataUrl
+      for thumbnailElement in file.previewElement.querySelectorAll("[data-dz-thumbnail]")
+        thumbnailElement.alt = file.name
+        thumbnailElement.src = dataUrl
 
     
     # Called whenever an error occurs
     # Receives `file` and `message`
     error: (file, message) ->
       file.previewElement.classList.add "dz-error"
-      file.previewElement.querySelector("[data-dz-errormessage]").textContent = message
+      node.textContent = message for node in file.previewElement.querySelectorAll("[data-dz-errormessage]")
     
     errormultiple: noop
     
@@ -337,7 +337,7 @@ class Dropzone extends Em
     # Receives `file`, `progress` (percentage 0-100) and `bytesSent`.
     # To get the total number of bytes of the file, use `file.size`
     uploadprogress: (file, progress, bytesSent) ->
-      file.previewElement.querySelector("[data-dz-uploadprogress]").style.width = "#{progress}%"
+      node.style.width = "#{progress}%" for node in file.previewElement.querySelectorAll("[data-dz-uploadprogress]")
 
     # Called whenever the total upload progress gets updated.
     # Called with totalUploadProgress (0-100), totalBytes and totalBytesSent


### PR DESCRIPTION
Let previewTemplate have zero or more
elements that represent data - filename, size, etc.
This will in effect make all fields optional.

Sorry I didn't open an issue for it first to discuss, but it was such a small change anyways. What do you think?
