### PR TITLE
Trim preview template so that createElement doesn't pick up an empty tex...

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -277,7 +277,7 @@ class Dropzone extends Em
     # Called when a file is added to the queue
     # Receives `file`
     addedfile: (file) ->
-      file.previewElement = Dropzone.createElement @options.previewTemplate
+      file.previewElement = Dropzone.createElement @options.previewTemplate.trim()
       file.previewTemplate = file.previewElement # Backwards compatibility
 
       @previewsContainer.appendChild file.previewElement


### PR DESCRIPTION
Fixed a bug I encountered where I was loading providing a preview template like the below:

```
this.dropzone = new Dropzone(this.$el.find('form').get(0), {
  previewsContainer: this.$el.find('.dz-prev-container').get(0)
});

<script id="create-idea-dz-preview" type="text/template">
  <div class="dz-preview dz-file-preview">
    ...
  </div>
</script>
```

Then when creating the `previewElement` from the template using `Dropzone.createElement` it returns the text node rather than the container div and then throws an error when it tries to access `querySelector`.
