### PR TITLE
componentbuild

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -21,7 +21,7 @@ module.exports = (grunt) ->
         files:
           "test/test.js": "test/*.coffee"
 
-    component_build:
+    componentbuild:
       app:
         output: "build/"
         name: "build"
@@ -87,6 +87,6 @@ module.exports = (grunt) ->
 
   grunt.registerTask "css", "Compile the stylus files to css", [ "stylus" ]
 
-  grunt.registerTask "js", "Compile coffeescript and create all download files", [ "coffee", "component_build", "copy", "concat" ]
+  grunt.registerTask "js", "Compile coffeescript and create all download files", [ "coffee", "componentbuild", "copy", "concat" ]
 
   grunt.registerTask "downloads", [ "js", "css", "uglify" ]


### PR DESCRIPTION
I got this error:

```
$ grunt
Warning: Task "component_build" not found. Use --force to continue.

Aborted due to warnings.
```

This change seemed to fix it.
