### PR TITLE
"Multiple" attribute should be applied when maxFiles > 1

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -21,7 +21,7 @@ module.exports = (grunt) ->
         files:
           "test/test.js": "test/*.coffee"
 
-    component_build:
+    componentbuild:
       app:
         output: "build/"
         name: "build"
@@ -87,6 +87,6 @@ module.exports = (grunt) ->
 
   grunt.registerTask "css", "Compile the stylus files to css", [ "stylus" ]
 
-  grunt.registerTask "js", "Compile coffeescript", [ "coffee", "component_build", "copy", "concat" ]
+  grunt.registerTask "js", "Compile coffeescript", [ "coffee", "componentbuild", "copy", "concat" ]
 
-  grunt.registerTask "downloads", "Compile all stylus and coffeescript files and generate the download files" [ "js", "css", "uglify" ]
+  grunt.registerTask "downloads", "Compile all stylus and coffeescript files and generate the download files", [ "js", "css", "uglify" ]

--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -482,7 +482,7 @@ class Dropzone extends Em
         document.body.removeChild @hiddenFileInput if @hiddenFileInput
         @hiddenFileInput = document.createElement "input"
         @hiddenFileInput.setAttribute "type", "file"
-        @hiddenFileInput.setAttribute "multiple", "multiple"
+        @hiddenFileInput.setAttribute "multiple", "multiple" if !@options.maxFiles? || @options.maxFiles > 1
 
         @hiddenFileInput.setAttribute "accept", @options.acceptedFiles if @options.acceptedFiles?
 


### PR DESCRIPTION
If maxFiles is one the user should only be able to select one file from dialog.
Also fixed Gruntfile errors
