### PR TITLE
Fix IE 11 bug with e.dataTransfer.effectAllowed

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -547,7 +547,8 @@ class Dropzone extends Em
           "dragover": (e) =>
             # Makes it possible to drag files from chrome's download bar
             # http://stackoverflow.com/questions/19526430/drag-and-drop-file-uploads-from-chrome-downloads-bar
-            efct = e.dataTransfer.effectAllowed
+            # Try is required to prevent bug in Internet Explorer 11 (SCRIPT65535 exception)
+            try efct = e.dataTransfer.effectAllowed
             e.dataTransfer.dropEffect = if 'move' == efct or 'linkMove' == efct then 'move' else 'copy'
 
             noPropagation e


### PR DESCRIPTION
Internet Explorer 11 throws an exception (SCRIPT65535) when trying to
read the dataTransfer.effectAllowed property of a DragEvent. Wrapping it
in a try-catch allows dragging files from the Chrome download bar
without affecting Internet Explorer.
