### PR TITLE
Fix processing of _thumbnailQueue on errors.

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -872,6 +872,8 @@ class Dropzone extends Em
 
         @emit "thumbnail", file, thumbnail
         callback() if callback?
+        
+      img.onerror = callback
 
       img.src = fileReader.result
 


### PR DESCRIPTION
Calls the createThumbnail callback on error to process next thumbnail in the queue. Otherwise the thumbnail generation stops, if there is an image, which can not be loaded successfully into an image tag (e.g. image/tiff, image/x-xbitmap).
