### PR TITLE
Fix empty dir when installing with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "downloads/dropzone.min.js"
     ],
   "ignore": [
-    "/*",
+    "*",
+    "!downloads",
     "!downloads/*"
   ]
 }


### PR DESCRIPTION
The ignore field in `bower.json` causes an empty dir when installing dropzone with bower. The current negation pattern is invalid, because you have to unignore `downloads` folder first in order to unignore its content.

This PR fixes this issue.
