### PR TITLE
Modified camelize(str) function to allow compatibility with old browser that do not support ES5

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1187,7 +1187,7 @@ Dropzone.isBrowserSupported = ->
 without = (list, rejectedItem) -> item for item in list when item isnt rejectedItem
 
 # abc-def_ghi -> abcDefGhi
-camelize = (str) -> str.replace /[\-_](\w)/g, (match) -> match[1].toUpperCase()
+camelize = (str) -> str.replace /[\-_](\w)/g, (match) -> match.charAt(1).toUpperCase()
 
 # Creates an element from string
 Dropzone.createElement = (string) ->


### PR DESCRIPTION
Changed from match[1] to match.charAt(1) because there are still some browsers that do not support ES5 yet (incredible I know ...) Internet Explorer I'm looking at you !. 
