### PR TITLE
paramName option allowed to be a function

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -618,10 +618,12 @@ class Dropzone extends Em
   # This code has to pass in IE7 :(
   getFallbackForm: ->
     return existingFallback if existingFallback = @getExistingFallback()
+    pn = @options.paramName
+    pnVal = if typeof pn is "function" then pn 0 else "#{pn}#{if @options.uploadMultiple then "[]" else ""}"
 
     fieldsString = """<div class="dz-fallback">"""
     fieldsString += """<p>#{@options.dictFallbackText}</p>""" if @options.dictFallbackText
-    fieldsString += """<input type="file" name="#{@options.paramName}#{if @options.uploadMultiple then "[]" else ""}" #{if @options.uploadMultiple then 'multiple="multiple"' } /><input type="submit" value="Upload!"></div>"""
+    fieldsString += """<input type="file" name="#{pnVal}" #{if @options.uploadMultiple then 'multiple="multiple"' } /><input type="submit" value="Upload!"></div>"""
 
     fields = Dropzone.createElement fieldsString
     if @element.tagName isnt "FORM"
@@ -1054,7 +1056,9 @@ class Dropzone extends Em
     # Finally add the file
     # Has to be last because some servers (eg: S3) expect the file to be the
     # last parameter
-    formData.append "#{@options.paramName}#{if @options.uploadMultiple then "[]" else ""}", file, file.name for file in files
+    pn = @options.paramName
+    pnGen = (n) -> if typeof pn is "function" then pn n else "#{pn}#{if @options.uploadMultiple then "[]" else ""}"
+    formData.append pnGen(i), files[i], files[i].name for i in [0..files.length-1]
 
     xhr.send formData
 


### PR DESCRIPTION
This is for https://github.com/enyo/dropzone/issues/424.
Now, the paramName option can be a function taking a numeric argument.
You can do:
var myDropzone = new Dropzone("div#myId", {paramName: function(n) {"file[" + n + "]");}};
