### PR TITLE
Don't ignore the downloads folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
   ],
   "ignore": [
     "*",
+    "!downloads",
     "!downloads/**/*"
   ]
 }


### PR DESCRIPTION
Upon deploying to Heroku today my version of dropzone got bumped to 3.1.0 and sprockets asset precompilation subsequently failed with the following error:

```
Sprockets::FileNotFound: couldn't find file 'dropzone/downloads/dropzone.min' (in /tmp/build_e383b5fa-d6d0-4348-96a6-8348c7ce03c5/app/assets/javascripts/application.js:17
```

I managed to narrow the issue down to the changes from commit 63e665bc1056b67356747f70edde7b5ea56c53d3. Adding back the directive to not ignore the `downloads` folder fixed the issue for me.
