### PR TITLE
Skip thumbnail creation for SVG files - use the SVG itself instead

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -886,6 +886,13 @@ class Dropzone extends Em
     fileReader = new FileReader
 
     fileReader.onload = =>
+
+      # Don't bother creating a thumbnail for SVG images since they're vector
+      if file.type == "image/svg+xml"
+        @emit "thumbnail", file, fileReader.result
+        callback() if callback?
+        return
+
       # Not using `new Image` here because of a bug in latest Chrome versions.
       # See https://github.com/enyo/dropzone/pull/226
       img = document.createElement "img"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1193,6 +1193,31 @@ describe "Dropzone", ->
 
           # dropzone.addFile mock1
 
+        describe "when file is SVG", ->
+          it "should use the SVG image itself", (done) ->
+
+            createBlob = (data, type) ->
+              try
+                new Blob([data], type: type)
+              catch e
+                BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder ||
+                    window.MozBlobBuilder || window.MSBlobBuilder
+                builder = new BlobBuilder()
+                builder.append(data.buffer || data)
+                builder.getBlob(type)
+
+            blob = createBlob('foo', 'image/svg+xml')
+
+            dropzone.on "thumbnail", (file, dataURI) ->
+              file.should.equal blob
+              fileReader = new FileReader
+              fileReader.onload = ->
+                fileReader.result.should.equal dataURI
+                done()
+              fileReader.readAsDataURL(file)
+
+            dropzone.createThumbnail(blob)
+
     describe "enqueueFile()", ->
       it "should be wrapped by enqueueFiles()", ->
         sinon.stub dropzone, "enqueueFile"


### PR DESCRIPTION
This fixes #641 and #579. I had to use an actual `Blob` in the tests or else `FileReader` would fail and there would be no way to check the result of `createThumbnail()`. Unfortunately support for `Blob`s is not consistent across browsers so I also had to use an ugly shim to create the `Blob`. I'm not familiar with Chai/Mocha, so I'm not sure if there's a better solution than just including the shim function inside the `it` block or not.

I know that the `CONTRIBUTING.md` indicates that discussion should happen prior to pull requests, but this issue was breaking functionality for one of our clients so I was directed to get a forked solution working ASAP. If I'm going in the wrong direction with this or if there's anything else I should be doing to make this more helpful I'm all ears.
