### PR TITLE
Changed "main" to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "upload"
   ],
   "homepage": "http://www.dropzonejs.com",
-  "main": [
-    "./lib/dropzone.js"
-  ],
+  "main": "./lib/dropzone.js",
   "maintainers": [
     {
       "name": "Matias Meno",


### PR DESCRIPTION
This fixes issue with Browserify https://github.com/enyo/dropzone/issues/597

According to [this](https://www.npmjs.org/doc/package.json.html), `main` is an ID, I think a string is better suited for this than an array of one item. I'm not sure, if setting this field an array is even legal.
Moreover, thanks to `main` being a string, this module can work with Browserify.
