### PR TITLE
Added support for mobile capture attribute

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -138,7 +138,11 @@ class Dropzone extends Em
     previewsContainer: null
 
     # If null, no capture type will be specified
-    # If camera, .
+    # If camera, mobile devices will skip the file selection and choose camera
+    # If microphone, mobile devices will skip the file selection and choose the microphone
+    # If camcorder, mobile devices will skip the file selection and choose the camera in video mode
+    # On apple devices multiple must be set to false.  AcceptedFiles may need to
+    # be set to an appropriate mime type (e.g. "image/*", "audio/*", or "video/*").
     capture: null
 
     # Dictionary


### PR DESCRIPTION
I added an option that will allow using the capture attribute as defined and outlined by w3c (see section 5 of http://www.w3.org/TR/html-media-capture/).  Mobile browsers implement this specification with subtle differences from what the w3c outlines (see http://mobilehtml5.org/ts/?id=23).

It is impossible to write tests that would test this feature in the current test suite, but the current tests all pass.  I have tested the implementation on Chrome and "Internet" on Samsung Galaxy S5 and Samsung Note 3.  I also tested the implementation on Safari on iOS 7 the iPhone 5S.  The attribute is ignored in older browsers that do not support the capture attribute.
