### PR TITLE
Adds putFile() to allow users to pre-populate with existing files

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -845,6 +845,14 @@ class Dropzone extends Em
         @enqueueFile file if @options.autoQueue # Will set .accepted = true
       @_updateMaxFilesReachedClass()
 
+  putFile: (file) ->
+    file.upload =
+      progress: 100
+      total: file.size
+      bytesSent: file.size
+    file.status = Dropzone.SUCCESS
+    @files.push file
+    @emit "addedfile", file
 
   # Wrapper for enqueueFile
   enqueueFiles: (files) -> @enqueueFile file for file in files; null

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1145,7 +1145,12 @@ describe "Dropzone", ->
 
         dropzone.removeFile.callCount.should.eql 2
 
-
+      describe "putFile()", ->
+        it "should properly set the status of the file", ->
+          doneFunction = null
+          dropzone.accept = (file, done) -> doneFunction = done
+          dropzone.putFile mockFile
+          mockFile.status.should.eql Dropzone.SUCCESS
 
       describe "thumbnails", ->
         it "should properly queue the thumbnail creation", (done) ->


### PR DESCRIPTION
Allows the user to show which files were uploaded in an earlier session by using putFile to add those files to the existing state as though they had already been uploaded.
