### PR TITLE
Update documentation.md

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -62,7 +62,7 @@ The valid options are:
 | `method`                | Defaults to `"post"` and can be changed to `"put"` if necessary.
 | `parallelUploads`       | How many file uploads to process in parallel (See the *Enqueuing file uploads* section for more info)
 | `maxFilesize`           | in MB
-| `paramName`             | The name of the file param that gets transferred. Defaults to `file`.
+| `paramName`             | The name of the file param that gets transferred. Can be a function returning a string. Defaults to `file`.
 | `dictDefaultMessage`    | The message that gets displayed before any files are dropped. This is normally replaced by an image but defaults to "Drop files here to upload"
 | `dictFallbackMessage`   | If the browser is not supported, the default message will be replaced with this text. Defaults to "Your browser does not support drag'n'drop file uploads."
 | `dictFallbackText`      | This will be added before the file input files. If you provide a fallback element yourself, or if this option is `null` this will be ignored. Defaults to "Please use the fallback form below to upload your files like in the olden days."


### PR DESCRIPTION
I've been confused by inconsistent behaviour comparing to native `<input type='file' multiple>` in `uploadMultiple: true` mode. Dropzone strangely adds postfixes to each file in request, so that it looks like `files[0], files[1], ...`, whereas native input's behaviour is just `file, file, ...`. To cover native behaviour it's not enough to set `paramName: 'file'`, you rather need to define a function: `paramName: function(){return 'file'}`, but that isn't clear from the docs.

I think that maybe it is even worth noting separately somewhere in the docs, but at least you have to have it in API description.
