### PR TITLE
Allow functions or strings for URL options.

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -988,6 +988,11 @@ class Dropzone extends Em
 
     @processQueue() if @options.autoProcessQueue
 
+  resolveOption = (option, args...) ->
+    if typeof option == 'function'
+      return option.apply(@, args)
+    option
+
   # Wrapper for uploadFiles()
   uploadFile: (file) -> @uploadFiles [ file ]
 
@@ -997,7 +1002,9 @@ class Dropzone extends Em
     # Put the xhr object in the file objects to be able to reference it later.
     file.xhr = xhr for file in files
 
-    xhr.open @options.method, @options.url, true
+    method = resolveOption @options.method, files
+    url = resolveOption @options.url, files
+    xhr.open method, url, true
 
     # Has to be after `.open()`. See https://github.com/enyo/dropzone/issues/179
     xhr.withCredentials = !!@options.withCredentials

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1252,6 +1252,37 @@ describe "Dropzone", ->
         dropzone.uploadFiles.callCount.should.equal 1
         dropzone.uploadFiles.calledWith([ mockFile ]).should.be.ok
 
+      it "should use url options if strings", (done) ->
+
+        dropzone.addFile mockFile
+
+        setTimeout ->
+          expect(requests.length).to.equal 1
+          expect(requests[0].url).to.equal dropzone.options.url
+          expect(requests[0].method).to.equal dropzone.options.method
+          done()
+        , 10
+
+      it "should call url options if functions", (done) ->
+        method = "PUT"
+        url = "/custom/upload/url"
+
+        dropzone.options.method = sinon.stub().returns method
+        dropzone.options.url = sinon.stub().returns url
+
+        dropzone.addFile mockFile
+
+        setTimeout ->
+          dropzone.options.method.callCount.should.equal 1
+          dropzone.options.url.callCount.should.equal 1
+          sinon.assert.calledWith dropzone.options.method, [mockFile]
+          sinon.assert.calledWith dropzone.options.url, [mockFile]
+          expect(requests.length).to.equal 1
+          expect(requests[0].url).to.equal url
+          expect(requests[0].method).to.equal method
+          done()
+        , 10
+
       it "should ignore the onreadystate callback if readyState != 4", (done) ->
         dropzone.addFile mockFile
 


### PR DESCRIPTION
Allow users to provide either a string or a function for the `method`
and `url` options. If a function is provided, call with `files` in
`uploadFiles`; else pass the string value. This can be useful when
different files need to be sent with different methods or URLs.

This patch came out of the development of [hgrid.js](https://github.com/centerforopenscience/hgrid), a hierarchical data browser that uses Dropzone for uploads to different directories. HGrid stores upload destination information on the file objects, so we had to monkey-patch Dropzone to allow it to use a function to build upload URLs and methods on a per-file basis. This patch would give users of Dropzone more control over how upload URLs and methods are built, but without complicating the API for developers who don't need that flexibility, since either a string or a function can be provided for `Dropzone.options.url` and `Dropzone.options.method`.
