### PR TITLE
Queuecomplete is missing in the event list

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -67,6 +67,7 @@ class Dropzone extends Em
     "reset"
     "maxfilesexceeded"
     "maxfilesreached"
+    "queuecomplete"
   ]
 
 


### PR DESCRIPTION
For me this case https://github.com/enyo/dropzone/issues/317#issuecomment-41248621, was also a problem.
