### PR TITLE
Fixing 'removedfile' function; additional check.

### DIFF
--- a/lib/dropzone.js
+++ b/lib/dropzone.js
@@ -296,7 +296,9 @@
         var _ref;
         if (file.previewElement) {
           if ((_ref = file.previewElement) != null) {
-            _ref.parentNode.removeChild(file.previewElement);
+            if (_ref.parentNode != null) {
+              _ref.parentNode.removeChild(file.previewElement);
+            }
           }
         }
         return this._updateMaxFilesReachedClass();


### PR DESCRIPTION
Tried to initialize dropzone after its html was removed from DOM.
It works this way.

Also, this needs to be updated in other files.
