### PR TITLE
remove duplicate  defaultOptions option filesizeBase

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -139,10 +139,6 @@ class Dropzone extends Emitter
     thumbnailWidth: 120
     thumbnailHeight: 120
 
-    # The base that is used to calculate the filesize. You can change this to
-    # 1024 if you would rather display kibibytes, mebibytes, etc...
-    filesizeBase: 1000
-
     # Can be used to limit the maximum number of files that will be handled
     # by this Dropzone
     maxFiles: null


### PR DESCRIPTION
This removes duplicate option `filesizeBase` in defaultOptions, that was introduced by commit https://github.com/enyo/dropzone/commit/3e4476303caa80df4ea995f487e1d9abab3e4512.

Below it, I left the better commented option.
Originally:
![screen shot 2015-03-17 at 10 48 30 am](https://cloud.githubusercontent.com/assets/4898263/6692615/4225c5be-cc93-11e4-82e7-5428992df0db.png)
