### PR TITLE
make sure files are not pending in added state

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -598,6 +598,8 @@ class Dropzone extends Emitter
 
   getUploadingFiles: -> @getFilesWithStatus Dropzone.UPLOADING
 
+  getAddedFiles: -> @getFilesWithStatus Dropzone.ADDED
+
   # Files that are either queued or uploading
   getActiveFiles: -> file for file in @files when file.status == Dropzone.UPLOADING or file.status == Dropzone.QUEUED
 
@@ -651,7 +653,7 @@ class Dropzone extends Emitter
 
     # Emit a `queuecomplete` event if all files finished uploading.
     @on "complete", (file) =>
-      if @getUploadingFiles().length == 0 and @getQueuedFiles().length == 0
+      if @getAddedFiles().length == 0 and @getUploadingFiles().length == 0 and @getQueuedFiles().length == 0
         # This needs to be deferred so that `queuecomplete` really triggers after `complete`
         setTimeout (=> @emit "queuecomplete"), 0
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1697,7 +1697,7 @@ describe "Dropzone", ->
             @_finished files, null, null
           ), 1
 
-        completedFiles = 0        
+        completedFiles = 0
         dropzone.on "complete", (file) ->
           completedFiles++
 


### PR DESCRIPTION
we just had an issue with the `queuecomplete` callback that got fired before the queue was actually completed.

files are still in the `added` state when the call to `complete` is processed, so the `queuecomplete` is triggered prematurely.

i think this is kind of a corner-case because we are doing another ajax call in the `completed` callback and have to wait for all those requests to return successfully.

i hope i gave enough context to make the issue clear. thx for your feedback.