### PR TITLE
don't send empty headers

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1177,7 +1177,8 @@ class Dropzone extends Emitter
 
     extend headers, @options.headers if @options.headers
 
-    xhr.setRequestHeader headerName, headerValue for headerName, headerValue of headers
+    for headerName, headerValue of headers
+      xhr.setRequestHeader headerName, headerValue if headerValue
 
     formData = new FormData()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1583,6 +1583,11 @@ describe "Dropzone", ->
           dropzone.uploadFile mockFile
           requests[0].requestHeaders["Foo-Header"].should.eql 'foobar'
 
+        it "should not set headers on the xhr object that are empty", ->
+          dropzone.options.headers = {"X-Requested-With": null}
+          dropzone.uploadFile mockFile
+          Object.keys(requests[0].requestHeaders).should.not.contain("X-Requested-With")
+
         it "should properly use the paramName without [n] as file upload if uploadMultiple is false", (done) ->
           dropzone.options.uploadMultiple = false
           dropzone.options.paramName = "myName"


### PR DESCRIPTION
CORS tends to be a bit picky.

in case a header is not allowed, setting it to empty might not be enough and the browser rejects the request.