### PR TITLE
remove duplicate property

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -142,16 +142,14 @@ class Dropzone extends Emitter
 
     # The base that is used to calculate the filesize. You can change this to
     # 1024 if you would rather display kibibytes, mebibytes, etc...
+    # 1024 is technically incorrect,
+    # because `1024 bytes` are `1 kibibyte` not `1 kilobyte`.
+    # You can change this to `1024` if you don't care about validity.
     filesizeBase: 1000
 
     # Can be used to limit the maximum number of files that will be handled
     # by this Dropzone
     maxFiles: null
-
-    # The base used to calculate filesizes. 1024 is technically incorrect,
-    # because `1024 bytes` are `1 kibibyte` not `1 kilobyte`.
-    # You can change this to `1024` if you don't care about validity.
-    filesizeBase: 1000
 
     # Can be an object of additional parameters to transfer to the server.
     # This is the same as adding hidden input fields in the form element.


### PR DESCRIPTION
because of the dupe, the generated file fails to parse under strict mode. this fixes said error.