### PR TITLE
Fixing #454 - Preview in table cell

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1350,7 +1350,10 @@ camelize = (str) -> str.replace /[\-_](\w)/g, (match) -> match.charAt(1).toUpper
 
 # Creates an element from string
 Dropzone.createElement = (string) ->
-  div = document.createElement "div"
+  if string.substr(0, 3) == '<tr'
+    div = document.createElement "tbody"
+  else
+    div = document.createElement "div"
   div.innerHTML = string
   div.childNodes[0]
 


### PR DESCRIPTION
This is a simple fix for #454 which does not allow dropzone preview to be in a table row. There's probably a more elegant solution, but until then, I think this is worth another 3 lines of code.