### PR TITLE
Added possibility to rename the filename before uploading

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -210,6 +210,10 @@ class Dropzone extends Emitter
     # be set to an appropriate mime type (e.g. "image/*", "audio/*", or "video/*").
     capture: null
 
+    # Before the file is appended to the formData, the function _renameFilename is performed for file.name
+    # which executes the function defined in renameFilename
+    renameFilename: null
+
     # Dictionary
 
     # The text used before any files are dropped
@@ -374,7 +378,7 @@ class Dropzone extends Emitter
         file.previewTemplate = file.previewElement # Backwards compatibility
 
         @previewsContainer.appendChild file.previewElement
-        node.textContent = file.name for node in file.previewElement.querySelectorAll("[data-dz-name]")
+        node.textContent = @_renameFilename(file.name) for node in file.previewElement.querySelectorAll("[data-dz-name]")
         node.innerHTML = @filesize file.size for node in file.previewElement.querySelectorAll("[data-dz-size]")
 
         if @options.addRemoveLinks
@@ -750,6 +754,12 @@ class Dropzone extends Emitter
       @options.paramName n
     else
       "#{@options.paramName}#{if @options.uploadMultiple then "[#{n}]" else ""}"
+
+  # If @options.renameFilename is a function,
+  # the function will be used to rename the file.name before appending it to the formData
+  _renameFilename: (name) ->
+    return name unless typeof @options.renameFilename is "function"
+    @options.renameFilename name
 
   # Returns a form that can be used as fallback if the browser does not support DragnDrop
   #
@@ -1212,7 +1222,7 @@ class Dropzone extends Emitter
     # Finally add the file
     # Has to be last because some servers (eg: S3) expect the file to be the
     # last parameter
-    formData.append @_getParamName(i), files[i], files[i].name for i in [0..files.length-1]
+    formData.append @_getParamName(i), files[i], @_renameFilename(files[i].name) for i in [0..files.length-1]
 
     xhr.send formData
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1650,6 +1650,25 @@ describe "Dropzone", ->
           , 10
 
 
+      it "should not change the file name if the options.renameFilename is not set", (done) ->
+        mockFilename = 'T3sT ;:_-.,!¨@&%&'
+
+        renamedFilename = dropzone._renameFilename(mockFilename)
+
+        setTimeout ->
+          renamedFilename.should.equal mockFilename
+          done()
+        , 10
+
+      it "should rename the file name if options.renamedFilename is set", (done) ->
+        dropzone.options.renameFilename = (name) ->
+          name.toLowerCase().replace(/[^\w]/gi, '')
+        renamedFilename = dropzone._renameFilename('T3sT ;:_-.,!¨@&%&')
+        setTimeout ->
+          renamedFilename.should.equal 't3st_'
+          done()
+        , 10
+
       describe "should properly set status of file", ->
         it "should correctly set `withCredentials` on the xhr object", (done) ->
           dropzone.addFile mockFile


### PR DESCRIPTION
A loot of people need to rename the filename before it's uploaded, myself included. So I quickly implemented the functionality.

See https://github.com/enyo/dropzone/issues/656 or https://github.com/enyo/dropzone/issues/722

Example how to use: (if the options.renameFilename is not specified, nothing changes)

```js
var cleanFilename = function (name) {
   return name.toLowerCase().replace(/[^\w]/gi, '');
};
var dropzone = new Dropzone("div#myId", { renameFilename: cleanFilename });
```

