### PR TITLE
Fixes enyo/dropzone#599

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -890,6 +890,8 @@ class Dropzone extends Emitter
             @addFile file
         else if entry.isDirectory
           @_addFilesFromDirectory entry, "#{path}/#{entry.name}"
+      if entries.length
+        dirReader.readEntries entriesReader, (error) -> console?.log? error
       return
 
     dirReader.readEntries entriesReader, (error) -> console?.log? error


### PR DESCRIPTION
Fixes enyo/dropzone#599
Recursively call dirReader.readEntries to upload > 100 files in a folder.