### PR TITLE
Move xhr.send to a separate overridable method

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1212,8 +1212,10 @@ class Dropzone extends Emitter
     # last parameter
     formData.append @_getParamName(i), files[i], files[i].name for i in [0..files.length-1]
 
-    xhr.send formData
+    @submitRequest xhr, formData, files
 
+  submitRequest: (xhr, formData, files) ->
+    xhr.send formData
 
   # Called internally when processing is finished.
   # Individual callbacks have to be called in the appropriate sections.


### PR DESCRIPTION
This commit makes it possible to send files as body instead of form data, and make other overrides to both xhr and formData before the request is submitted.

For example:

```js
Dropzone.prototype.submitRequest = function(xhr, formData, files) {
  xhr.send(files[0]);
}
```