### PR TITLE
Add option for hidden input field container selector

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -200,6 +200,9 @@ class Dropzone extends Emitter
     # If false, previews won't be rendered.
     previewsContainer: null
 
+    # Selector for hidden input container
+    hiddenInputContainer: "body"
+
     # If null, no capture type will be specified
     # If camera, mobile devices will skip the file selection and choose camera
     # If microphone, mobile devices will skip the file selection and choose the microphone
@@ -478,7 +481,7 @@ class Dropzone extends Emitter
     maxfilesexceeded: noop
 
     maxfilesreached: noop
-    
+
     queuecomplete: noop
 
     addedfiles: noop
@@ -617,7 +620,7 @@ class Dropzone extends Emitter
 
     if @clickableElements.length
       setupHiddenFileInput = =>
-        document.body.removeChild @hiddenFileInput if @hiddenFileInput
+        @hiddenFileInput.parentNode.removeChild @hiddenFileInput if @hiddenFileInput
         @hiddenFileInput = document.createElement "input"
         @hiddenFileInput.setAttribute "type", "file"
         @hiddenFileInput.setAttribute "multiple", "multiple" if !@options.maxFiles? || @options.maxFiles > 1
@@ -634,7 +637,7 @@ class Dropzone extends Emitter
         @hiddenFileInput.style.left = "0"
         @hiddenFileInput.style.height = "0"
         @hiddenFileInput.style.width = "0"
-        document.body.appendChild @hiddenFileInput
+        document.querySelector(@options.hiddenInputContainer).appendChild @hiddenFileInput
         @hiddenFileInput.addEventListener "change", =>
           files = @hiddenFileInput.files
           @addFile file for file in files if files.length
@@ -1025,7 +1028,7 @@ class Dropzone extends Emitter
 
       @emit "thumbnail", file, thumbnail
       callback() if callback?
-      
+
     img.onerror = callback if callback?
 
     img.src = imageUrl


### PR DESCRIPTION
I'm using Dropzone on a webapp with Turbolinks 3 architecture (https://github.com/rails/turbolinks). It means that when navigating through links - new HTML is fetched and body is replaced with JS. But also, it is possible to keep some of the DOM nodes in that process so they are permanent.

Basically, I want to initialize Dropzone once and have the uploads active while I'm navigating through my app. To do that, I need to place hidden file input in the "permanent" container and not directly into the body. Otherwise, every Turbolinks body change would remove the hidden input and disable Dropzone from working.

This commit fixed my issue. The change is simple and doesn't interfere in any way with other parts of Dropzone - so it would be great if it can be merged into original repo.