### PR TITLE
Adding additional title field to show file name on hover

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -380,6 +380,7 @@ class Dropzone extends Emitter
 
         @previewsContainer.appendChild file.previewElement
         node.textContent = file.name for node in file.previewElement.querySelectorAll("[data-dz-name]")
+        node.title = file.name for node in file.previewElement.querySelectorAll("[data-dz-name]")
         node.innerHTML = @filesize file.size for node in file.previewElement.querySelectorAll("[data-dz-size]")
 
         if @options.addRemoveLinks


### PR DESCRIPTION
Expected final result : `<span class="name" data-dz-name title="week1.ppt">week1.ppt</span>`

The idea is to show file name when mouse is hovered over text. The information will be shown as a tooltip text when the mouse moves over the element.

I came across the use case when I was handling my view for files with long names. I use "text-overflow: ellipsis;" to truncate text and then above change helps me to display full file name as tool tip