### PR TITLE
Update docs with correct api call

### DIFF
--- a/_includes/configuration-options.html
+++ b/_includes/configuration-options.html
@@ -232,7 +232,7 @@
         image. Change it to fulfill your needs but make sure to properly
         provide all elements. You can include the HTML in your page in a
         <code>&lt;div id="preview-template" style="display: none;"&gt;&lt;/div&gt;</code> container, and set
-        it like this: <code>previewTemplate: document.querySelector('preview-template').innerHTML</code>.
+        it like this: <code>previewTemplate: document.getElementById('preview-template').innerHTML</code>.
       </td>
 
     </tr><tr id="config-forceFallback">


### PR DESCRIPTION
`document.querySelector('preview-template')` returns null for a given DOM