### PR TITLE
Blacklist Opera Mini 9 on Windows Phone.

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1338,7 +1338,8 @@ Dropzone.discover = ->
 #
 Dropzone.blacklistedBrowsers = [
   # The mac os version of opera 12 seems to have a problem with the File drag'n'drop API.
-  /opera.*Macintosh.*version\/12/i
+  # Also Windows Phone Opera Mini 9 (which identifies as version 12 also).
+  /opera.*(Macintosh|Windows Phone).*version\/12/i
   # /MSIE\ 10/i
 ]
 


### PR DESCRIPTION
Hopefully fixes #100. We had a report from someone with a Windows Phone running Opera Mini 9 that our dropzone implementation wasn't working, and adding this enabled the fallback to appear instead.
