### PR TITLE
RemoveFile now checks if the specified file is part of the collection.

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -996,6 +996,8 @@ class Dropzone extends Emitter
 
   # Can be called by the user to remove a file
   removeFile: (file) ->
+    if file not in @files
+      return
     @cancelUpload file if file.status == Dropzone.UPLOADING
     @files = without @files, file
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -709,6 +709,23 @@ describe "Dropzone", ->
           done()
         , 10
 
+      it "should check if the file is part of the collection", (done) ->
+        mockFile = getMockFile()
+        dropzone.uploadFile = (file) ->
+        dropzone.accept = (file, done) -> done()
+
+        sinon.stub dropzone, "cancelUpload"
+
+        dropzone.addFile mockFile
+        setTimeout ->
+          dropzone.cancelUpload.callCount.should.equal 0
+          dropzone.removeFile mockFile
+          dropzone.cancelUpload.callCount.should.equal 1
+          dropzone.removeFile mockFile
+          dropzone.cancelUpload.callCount.should.equal 1
+          done()
+        , 10
+
     describe ".cancelUpload()", ->
       it "should properly cancel upload if file currently uploading", (done) ->
         mockFile = getMockFile()


### PR DESCRIPTION
The current versions will throw a 'null reference exception' when removeFile is called again with the same file. This can be prevented with a null check for this inside removedfile. But I think that is better to add a check to removeFile that makes sure the specified file is still part of the collection. This also prevents cancelUpload from being called multiple times.
