### PR TITLE
Add additional file argument to renameFilename.

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -211,7 +211,7 @@ class Dropzone extends Emitter
     # be set to an appropriate mime type (e.g. "image/*", "audio/*", or "video/*").
     capture: null
 
-    # Before the file is appended to the formData, the function _renameFilename is performed for file.name
+    # Before the file is appended to the formData, the function _renameFilename is performed for file.name, file
     # which executes the function defined in renameFilename
     renameFilename: null
 
@@ -383,7 +383,7 @@ class Dropzone extends Emitter
         file.previewTemplate = file.previewElement # Backwards compatibility
 
         @previewsContainer.appendChild file.previewElement
-        node.textContent = @_renameFilename(file.name) for node in file.previewElement.querySelectorAll("[data-dz-name]")
+        node.textContent = @_renameFilename(file.name, file) for node in file.previewElement.querySelectorAll("[data-dz-name]")
         node.innerHTML = @filesize file.size for node in file.previewElement.querySelectorAll("[data-dz-size]")
 
         if @options.addRemoveLinks
@@ -762,9 +762,9 @@ class Dropzone extends Emitter
 
   # If @options.renameFilename is a function,
   # the function will be used to rename the file.name before appending it to the formData
-  _renameFilename: (name) ->
+  _renameFilename: (name, file) ->
     return name unless typeof @options.renameFilename is "function"
-    @options.renameFilename name
+    @options.renameFilename name, file
 
   # Returns a form that can be used as fallback if the browser does not support DragnDrop
   #
@@ -1242,7 +1242,7 @@ class Dropzone extends Emitter
     # Finally add the file
     # Has to be last because some servers (eg: S3) expect the file to be the
     # last parameter
-    formData.append @_getParamName(i), files[i], @_renameFilename(files[i].name) for i in [0..files.length-1]
+    formData.append @_getParamName(i), files[i], @_renameFilename(files[i].name, files[i]) for i in [0..files.length-1]
 
     @submitRequest xhr, formData, files
 


### PR DESCRIPTION
This adds an additional `file` argument to the `renameFilename` function. This allows for more powerful renaming to happen in the `renameFilename` function -- we know basically everything there is to know about the file, instead of just its filename. Knowing just the filename is sometimes too limited.

My particular use case is to show and send to the server as the filename the full path, instead of just the filename, if `fullPath` is set. With this change, this can be achieved by adding the following configuration entry:
```
renameFilename: function(filename, file) {
    return file.fullPath ? file.fullPath : filename;
}
```

This change is clearly backwards compatible.
Tests are still passing.
@enyo Please review.