### PR TITLE
Add the possibility to set timeout on Options

### DIFF
--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -131,6 +131,7 @@ class Dropzone extends Emitter
     url: null
     method: "post"
     withCredentials: no
+    timeout: 30000 # timeout in milliseconds
     parallelUploads: 2
     uploadMultiple: no # Whether to send multiple files in one request.
     maxFilesize: 256 # in MB
@@ -1136,6 +1137,7 @@ class Dropzone extends Emitter
     # Put the xhr object in the file objects to be able to reference it later.
     file.xhr = xhr for file in files
 
+    xhr.timeout = resolveOption @options.timeout, files
     method = resolveOption @options.method, files
     url = resolveOption @options.url, files
     xhr.open method, url, true

--- a/src/dropzone.coffee
+++ b/src/dropzone.coffee
@@ -1133,11 +1133,11 @@ class Dropzone extends Emitter
 
   uploadFiles: (files) ->
     xhr = new XMLHttpRequest()
-
+    xhr.timeout = resolveOption @options.timeout, files
+    
     # Put the xhr object in the file objects to be able to reference it later.
     file.xhr = xhr for file in files
 
-    xhr.timeout = resolveOption @options.timeout, files
     method = resolveOption @options.method, files
     url = resolveOption @options.url, files
     xhr.open method, url, true


### PR DESCRIPTION
Add the possibility to set timeout, when you have $.ajaxsetup timeout as global, but for this case, file uploads you want to have a custom timeout without modify global timeout
