### PR TITLE
createThumbnailFromUrl Callback with file var

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -1226,7 +1226,7 @@
             drawImageIOSFix(ctx, img, (ref = resizeInfo.srcX) != null ? ref : 0, (ref1 = resizeInfo.srcY) != null ? ref1 : 0, resizeInfo.srcWidth, resizeInfo.srcHeight, (ref2 = resizeInfo.trgX) != null ? ref2 : 0, (ref3 = resizeInfo.trgY) != null ? ref3 : 0, resizeInfo.trgWidth, resizeInfo.trgHeight);
             thumbnail = canvas.toDataURL("image/png");
             if (callback != null) {
-              return callback(thumbnail, canvas);
+              return callback(thumbnail, canvas, file);
             }
           });
         };


### PR DESCRIPTION
The callback from function, createThumbnailFromUrl, should also send the file var as the third parameter.

Without this parameter, I couldn't find a reliable way to link the Thumbnail with the image and to keep the order of the files.

You can find an explanatory code below :

var mocks= [];
for (i=1; i<=5; i++) {
	mocks[i] = {dataURL: "https://www.google.com/"+i+".jpg", name: i, size: 1234, kind: 'image'};
	dropz.emit("addedfile", mocks[i]);
	dropz.files.push(mocks[i]);
	dropz.createThumbnailFromUrl(mocks[i], 120, 120, 'crop', null, function(thumbnail, canvas, file) {
		dropz.emit('thumbnail', file, thumbnail);
	}, "anonymous");
	dropz.emit("complete", mocks[i]);
}