### PR TITLE
Exif + Rotation + Resize fix

### DIFF
--- a/dist/dropzone.js
+++ b/dist/dropzone.js
@@ -2086,8 +2086,11 @@ function (_Emitter) {
           var resizedDataURL = canvas.toDataURL(resizeMimeType, _this11.options.resizeQuality);
 
           if (resizeMimeType === 'image/jpeg' || resizeMimeType === 'image/jpg') {
+            /* Commented out because Resize + Exif + Rotation combo breaks the Orientation
+            /* You do not want to restore unless exif updated after rotation */
+
             // Now add the original EXIF information
-            resizedDataURL = ExifRestore.restore(file.dataURL, resizedDataURL);
+            // resizedDataURL = ExifRestore.restore(file.dataURL, resizedDataURL);
           }
 
           return callback(Dropzone.dataURItoBlob(resizedDataURL));


### PR DESCRIPTION
Hey there,

We found an issue with images with Orientation exif data and dropzone resize options enabled. The images get properly resized by Dropzone but because the Exif gets restored with the original information, on the uploaded location they are wrongly tagged.

For example, if you have an image that is 180º rotated, Dropzone properly resize and rotates it but once the ExifRestore kicks in, the 180º rotation gets re-applied. Any server side manipulation of the image will wrongly rotate the image again to fix the orientation.

My fix is not ideal in anyway because I am just commenting out the line that restores the original Exif data, which is fine for our use at the moment. However, ideally, Dropzone should do its rotation + resize to the settings passed in by the user and after that it should rotate back to the original orientation so the exif data remains accurate.

Thanks,