### PR TITLE
Add an aria-label to the hidden dropzone input

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -246,6 +246,7 @@ export default class Dropzone extends Emitter {
           this.hiddenFileInput.setAttribute("multiple", "multiple");
         }
         this.hiddenFileInput.className = "dz-hidden-input";
+        this.hiddenFileInput.ariaLabel = "dropzone hidden input";
 
         if (this.options.acceptedFiles !== null) {
           this.hiddenFileInput.setAttribute(


### PR DESCRIPTION
Hello,

In order to improve accessibility, inputs must have a label and the
dz-hidden-input didn't have one.

Note that the `ariaLabel` attribute [is not supported in Firefox](https://caniuse.com/mdn-api_element_arialabel) but everywhere else it is.