### PR TITLE
Add `maxFilesizeBase` to options

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -742,13 +742,14 @@ export default class Dropzone extends Emitter {
   // This function checks the filesize, and if the file.type passes the
   // `acceptedFiles` check.
   accept(file, done) {
+    const base = this.options.maxFilesizeBase || 1024 * 1024;
     if (
       this.options.maxFilesize &&
-      file.size > this.options.maxFilesize * 1024 * 1024
+      file.size > this.options.maxFilesize * base
     ) {
       done(
         this.options.dictFileTooBig
-          .replace("{{filesize}}", Math.round(file.size / 1024 / 10.24) / 100)
+          .replace("{{filesize}}", Math.round(file.size * 100 / base) / 100)
           .replace("{{maxFilesize}}", this.options.maxFilesize)
       );
     } else if (!Dropzone.isValidFile(file, this.options.acceptedFiles)) {

--- a/src/options.js
+++ b/src/options.js
@@ -78,9 +78,14 @@ let defaultOptions = {
   retryChunksLimit: 3,
 
   /**
-   * The maximum filesize (in bytes) that is allowed to be uploaded.
+   * The maximum filesize that is allowed to be uploaded, as multiple of maxFilesizeBase (default: 256 MiB).
    */
   maxFilesize: 256,
+
+  /**
+   * The base multiplier to use for maximum filesize calculation (default: 1 MiB).
+   */
+  maxFilesizeBase: 1024 * 1024,
 
   /**
    * The name of the file param that gets transferred.

--- a/test/test.js
+++ b/test/test.js
@@ -1041,8 +1041,8 @@ describe("Dropzone", function () {
       {
         dropzone.options.maxFilesizeBase = 1000 * 1000;
         dropzone.options.dictFileTooBig = "File is too big ({{filesize}} MB). Max: {{maxFilesize}} MB.";
-        dropzone.accept({ size: 4.5 * 1000 * 1000, type: "audio/mp3" }, (err) =>
-          err.should.eql("File is too big (4.5 MB). Max: 4 MB.")
+        dropzone.accept({ size: 12345678, type: "audio/mp3" }, (err) =>
+          err.should.eql("File is too big (12.35 MB). Max: 4 MB.")
         );
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1037,6 +1037,15 @@ describe("Dropzone", function () {
           err.should.eql("File is too big (10MiB). Max filesize: 4MiB.")
         ));
 
+      it("shouldn't pass if the filesize is too big with maxFilesizeBase", () =>
+      {
+        dropzone.options.maxFilesizeBase = 1000 * 1000;
+        dropzone.options.dictFileTooBig = "File is too big ({{filesize}} MB). Max: {{maxFilesize}} MB.";
+        dropzone.accept({ size: 4.5 * 1000 * 1000, type: "audio/mp3" }, (err) =>
+          err.should.eql("File is too big (4.5 MB). Max: 4 MB.")
+        );
+      });
+
       it("should properly accept files which mime types are listed in acceptedFiles", function () {
         dropzone.accept(
           { type: "audio/mp3" },


### PR DESCRIPTION
Adds `maxFilesizeBase` to make `maxFilesize` more configurable, specifically to support calculating in MB rather than MiB to avoid inconsistent display (different size, different units):

![msedge_PJuDR8CKBD](https://user-images.githubusercontent.com/133987/117713322-22fd3980-b19b-11eb-9d89-c6bc7a94f048.png)

Open to other suggestions, but this seemed the easiest way to avoid breaking changes.