### PR TITLE
Adds boolean parameter 'sendFileAsBody'

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -129,6 +129,14 @@ export default class Dropzone extends Emitter {
       throw new Error("You cannot set both: uploadMultiple and chunking.");
     }
 
+    if (this.options.sendFileAsBody && this.options.chunking) {
+      throw new Error("You cannot set both: sendFileAsBody and chunking.");
+    }
+
+    if (this.options.sendFileAsBody && this.options.uploadMultiple) {
+      throw new Error("You cannot set both: sendFileAsBody and uploadMultiple.");
+    }
+
     // Backwards compatibility
     if (this.options.acceptedMimeTypes) {
       this.options.acceptedFiles = this.options.acceptedMimeTypes;
@@ -1392,6 +1400,10 @@ export default class Dropzone extends Emitter {
       "X-Requested-With": "XMLHttpRequest",
     };
 
+    if (this.options.sendFileAsBody) {
+      headers["Content-Type"] = files[0].type;
+    }
+
     if (this.options.headers) {
       Dropzone.extend(headers, this.options.headers);
     }
@@ -1654,7 +1666,11 @@ export default class Dropzone extends Emitter {
       );
       return;
     }
-    xhr.send(formData);
+    if (this.options.sendFileAsBody) {
+      xhr.send(files[0]);
+    } else {
+      xhr.send(formData);
+    }
   }
 
   // Called internally when processing is finished.

--- a/src/options.js
+++ b/src/options.js
@@ -78,6 +78,12 @@ let defaultOptions = {
   retryChunksLimit: 3,
 
   /**
+   * If `true`, the file will be uploaded as the body of the request instead of a form parameter. If this is used,
+   * uploadMultiple and chunking is disabled and any other form parameters will not be send.
+   */
+  sendFileAsBody: false,
+
+  /**
    * The maximum filesize (in bytes) that is allowed to be uploaded.
    */
   maxFilesize: 256,


### PR DESCRIPTION
This will change the outgoing request to not send a form at all and instead send the file as the body of the request. This is useful for web servers which will itself upload the file to another source (for example S3), so they can more easily forward the file content while still receiving the request. This will show the user a more accurate progress.