### PR TITLE
Send at least one chunk if filesize is 0

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1221,6 +1221,9 @@ export default class Dropzone extends Emitter {
         files[0].upload.totalChunkCount = Math.ceil(
           transformedFile.size / this.options.chunkSize
         );
+        if (transformedFile.size === 0) {
+          files[0].upload.totalChunkCount = 1;
+        }
       }
 
       if (files[0].upload.chunked) {


### PR DESCRIPTION
Fix for #1982

If the filesize is zero, this ensures that at least one chunk of empty data is sent. Without this patch, dropzone gets stuck when uploading 0 byte files