### PR TITLE
Fix improper grammar.

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -357,7 +357,7 @@ let defaultOptions = {
    * Displayed if `maxFiles` is st and exceeded.
    * The string `{{maxFiles}}` will be replaced by the configuration value.
    */
-  dictMaxFilesExceeded: "You can not upload any more files.",
+  dictMaxFilesExceeded: "You cannot upload any more files.",
 
   /**
    * Allows you to translate the different units. Starting with `tb` for terabytes and going down to


### PR DESCRIPTION
Fixing a 1-character typo. "can not" is not proper grammar. Must be "cannot" in this sense.