### PR TITLE
Add `canvasFill` option

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -842,6 +842,7 @@ export default class Dropzone extends Emitter {
       this.options.thumbnailHeight,
       this.options.thumbnailMethod,
       true,
+      this.options.canvasFill,
       (dataUrl) => {
         this.emit("thumbnail", file, dataUrl);
         this._processingThumbnail = false;
@@ -880,13 +881,14 @@ export default class Dropzone extends Emitter {
   // Resizes an image before it gets sent to the server. This function is the default behavior of
   // `options.transformFile` if `resizeWidth` or `resizeHeight` are set. The callback is invoked with
   // the resized blob.
-  resizeImage(file, width, height, resizeMethod, callback) {
+  resizeImage(file, width, height, resizeMethod, canvasFill, callback) {
     return this.createThumbnail(
       file,
       width,
       height,
       resizeMethod,
       true,
+      canvasFill,
       (dataUrl, canvas) => {
         if (canvas == null) {
           // The image has not been resized
@@ -913,7 +915,7 @@ export default class Dropzone extends Emitter {
     );
   }
 
-  createThumbnail(file, width, height, resizeMethod, fixOrientation, callback) {
+  createThumbnail(file, width, height, resizeMethod, resizeFillColor, fixOrientation, canvasFill, callback) {
     let fileReader = new FileReader();
 
     fileReader.onload = () => {
@@ -932,7 +934,9 @@ export default class Dropzone extends Emitter {
         width,
         height,
         resizeMethod,
+        resizeFillColor,
         fixOrientation,
+        canvasFill,
         callback
       );
     };
@@ -972,6 +976,7 @@ export default class Dropzone extends Emitter {
         this.options.thumbnailHeight,
         this.options.thumbnailMethod,
         this.options.fixOrientation,
+        this.options.canvasFill,
         onDone,
         crossOrigin
       );
@@ -984,6 +989,7 @@ export default class Dropzone extends Emitter {
     height,
     resizeMethod,
     fixOrientation,
+    canvasFill,
     callback,
     crossOrigin
   ) {
@@ -1076,6 +1082,7 @@ export default class Dropzone extends Emitter {
         drawImageIOSFix(
           ctx,
           img,
+          this.options.canvasFill,
           resizeInfo.srcX != null ? resizeInfo.srcX : 0,
           resizeInfo.srcY != null ? resizeInfo.srcY : 0,
           resizeInfo.srcWidth,
@@ -2075,9 +2082,9 @@ let detectVerticalSquash = function (img) {
 
 // A replacement for context.drawImage
 // (args are for source and destination).
-var drawImageIOSFix = function (ctx, img, sx, sy, sw, sh, dx, dy, dw, dh) {
+var drawImageIOSFix = function (ctx, img, fill, sx, sy, sw, sh, dx, dy, dw, dh) {
   let vertSquashRatio = detectVerticalSquash(img);
-  ctx.fillStyle = 'white';
+  ctx.fillStyle = fill;
   ctx.fillRect(0, 0, dw, dh);
   return ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh / vertSquashRatio);
 };

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -2077,6 +2077,8 @@ let detectVerticalSquash = function (img) {
 // (args are for source and destination).
 var drawImageIOSFix = function (ctx, img, sx, sy, sw, sh, dx, dy, dw, dh) {
   let vertSquashRatio = detectVerticalSquash(img);
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, dw, dh);
   return ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh / vertSquashRatio);
 };
 

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -915,7 +915,7 @@ export default class Dropzone extends Emitter {
     );
   }
 
-  createThumbnail(file, width, height, resizeMethod, resizeFillColor, fixOrientation, canvasFill, callback) {
+  createThumbnail(file, width, height, resizeMethod, fixOrientation, canvasFill, callback) {
     let fileReader = new FileReader();
 
     fileReader.onload = () => {
@@ -934,7 +934,6 @@ export default class Dropzone extends Emitter {
         width,
         height,
         resizeMethod,
-        resizeFillColor,
         fixOrientation,
         canvasFill,
         callback

--- a/src/options.js
+++ b/src/options.js
@@ -149,6 +149,13 @@ let defaultOptions = {
    */
   resizeMethod: "contain",
 
+
+  /**
+   * Specifies a background color for the image where target mimeType does not support transparency.
+   * Takes a string of any CSS color data type, see: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+   */
+  canvasFill: 'white', 
+
   /**
    * The base that is used to calculate the **displayed** filesize. You can
    * change this to 1024 if you would rather display kibibytes, mebibytes,
@@ -548,6 +555,7 @@ let defaultOptions = {
         this.options.resizeWidth,
         this.options.resizeHeight,
         this.options.resizeMethod,
+        this.options.canvasFill,
         done
       );
     } else {

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -1309,6 +1309,7 @@ describe("Dropzone", function () {
             thumbnailHeight,
             resizeMethod,
             fixOrientation,
+            canvasFill,
             callback
           ) {
             ct_file = file;
@@ -1361,6 +1362,7 @@ describe("Dropzone", function () {
               dropzone.options.thumbnailHeight,
               "crop",
               false,
+              dropzone.options.canvasFill,
               function (dataURI, canvas) {
                 let fileReader = new FileReader();
                 fileReader.onload = function () {


### PR DESCRIPTION
I found that when converting PNG with transparency to a JPG, the image ended up with a black background.

~~I added this as a proof-of-concept, but it really should be a configuration option. If this idea is worthwhile, I'm happy to pursue it via using an option like `resizeCanvasBackground` or something like that.~~

I ended up implementing `canvasFill` as an option.