### PR TITLE
uri-encode filename because of rfc6266 section-4.3

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -458,7 +458,7 @@ export default class Dropzone extends Emitter {
   // the function will be used to rename the file.name before appending it to the formData
   _renameFile(file) {
     if (typeof this.options.renameFile !== "function") {
-      return file.name;
+      return encodeURIComponent(file.name);
     }
     return this.options.renameFile(file);
   }


### PR DESCRIPTION
### Issue
It is treated as URI-encoded already when filename contains '%' so that the when original filename contains '%' like `a-%61.txt` then it is converted to `a-a.txt` at server-side.

### Reason
According to [RFC6266 section-4.3](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3), filename should be uri-encoded in form-data while in dropzone.js FormData append part passes raw filename via  _renameFile() as follows in src/dropzone.js:

> _renameFile(file) {
> ...
>      return file.name;
> ...
> filename: this._renameFile(file),
> ...
> formData.append(dataBlock.name, dataBlock.data, dataBlock.filename);

### Solution
This PR encode by encodeURIComponent() at _renameFile when renameFile hook is not defined.

(I didn't touch user-customized renameFile() so that user need to take care about '%' issue mentioned above.)