### PR TITLE
chunk concurr limit: add link to option 'parallelUploads'

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1302,7 +1302,14 @@ export default class Dropzone extends Emitter {
         };
 
         if (this.options.parallelChunkUploads) {
-          for (let i = 0; i < file.upload.totalChunkCount; i++) {
+          //for (let i = 0; i < file.upload.totalChunkCount; i++) {
+          //  handleNextChunk();
+          //}
+          const triggerCount = Math.min(
+            this.options.parallelChunkUploads === true? this.options.parallelUploads : this.options.parallelChunkUploads,
+            file.upload.totalChunkCount
+          );
+          for (let i = 0; i < triggerCount; i++) {
             handleNextChunk();
           }
         } else {

--- a/src/options.js
+++ b/src/options.js
@@ -65,6 +65,7 @@ let defaultOptions = {
 
   /**
    * If `true`, the individual chunks of a file are being uploaded simultaneously.
+   * The limit of concurrent connections is governed by `parallelUploads`.
    */
   parallelChunkUploads: false,
 


### PR DESCRIPTION
Hi

This aims to limit concurrent chunk uploads to the same value as `parallelUploads`.
This drastically reduces the io weight on the receiving end.

I found this fix from 4 years ago by another person at:
https://gitlab.com/meno/dropzone/-/merge_requests/53/diffs
and created a fresh PR.

I ask for review, since I tested this code only by edits at
https://unpkg.com/dropzone@5.9.3/dist/dropzone.js

Cheers!
