### PR TITLE
Fix duplicate files

### DIFF
--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -763,6 +763,9 @@ export default class Dropzone extends Emitter {
   }
 
   addFile(file) {
+    if (this.isFileDuplicate(file)) {
+      return;
+    }
     file.upload = {
       uuid: Dropzone.uuidv4(),
       progress: 0,
@@ -795,6 +798,10 @@ export default class Dropzone extends Emitter {
       }
       this._updateMaxFilesReachedClass();
     });
+  }
+  isFileDuplicate(newFile) {
+    return this.files.some(existingFile => 
+        existingFile.name === newFile.name && existingFile.size === newFile.size);
   }
 
   // Wrapper for enqueueFile


### PR DESCRIPTION
Regarding [this issue](https://github.com/dropzone/dropzone/issues/2265), this fix addresses the problem of duplicate files being created when they are dragged and dropped into the dropzone. This behavior is not desired as the user will already have the file after dropping it into the dropzone and does not require duplicates. Additionally, since the same file may be used frequently, creating duplicates is unnecessary.

To prevent duplicate files from being added to the dropzone, we check for the presence of another file with the same name and size. This process ensures that only unique files are accepted. By conducting this check, we can maintain the integrity of the files and avoid any possible errors.

**Validation**: A local test HTML page was created to replicate the issue. With the applied fix, the error did not recur, confirming the effectiveness of the solution.

Looking forward to any feedback or questions about this implementation.