### PR TITLE
parallelChunkUploads

### DIFF
--- a/.changeset/limit-parallel-chunk-uploads.md
+++ b/.changeset/limit-parallel-chunk-uploads.md
@@ -1,0 +1,5 @@
+---
+"dropzone": minor
+---
+
+`parallelChunkUploads: true` now starts at most `parallelUploads` chunks at a time rather than every chunk of the file at once. Pass a number to set a different limit, or `Infinity` to restore the previous behaviour.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1125,8 +1125,6 @@ export default class Dropzone extends Emitter {
         // uploadMultiple is not allowed with this option.
         let file = files[0];
         let transformedFile = transformedFiles[0];
-        let startedChunkCount = 0;
-
         file.upload.chunks = [];
 
         let handleNextChunk = () => {
@@ -1139,8 +1137,6 @@ export default class Dropzone extends Emitter {
 
           // This means, that all chunks have already been started.
           if (chunkIndex >= file.upload.totalChunkCount) return;
-
-          startedChunkCount++;
 
           let start = chunkIndex * chunkSize;
           let end = Math.min(start + chunkSize, transformedFile.size);
@@ -1194,7 +1190,20 @@ export default class Dropzone extends Emitter {
         };
 
         if (this.options.parallelChunkUploads) {
-          for (let i = 0; i < file.upload.totalChunkCount; i++) {
+          // Starting every chunk at once means a large file arrives as
+          // hundreds of simultaneous requests -- HTTP/1.1 queues most of them
+          // in the browser, but over HTTP/2 they all reach the server
+          // together. `true` defers to parallelUploads; a number sets its own
+          // limit. Whatever does not start now is picked up by
+          // finishedChunkUpload as earlier chunks complete.
+          let limit =
+            this.options.parallelChunkUploads === true
+              ? this.options.parallelUploads
+              : this.options.parallelChunkUploads;
+
+          // At least one, or nothing would ever start.
+          let startCount = Math.max(1, Math.min(limit, file.upload.totalChunkCount));
+          for (let i = 0; i < startCount; i++) {
             handleNextChunk();
           }
         } else {

--- a/src/options.js
+++ b/src/options.js
@@ -64,7 +64,9 @@ let defaultOptions = {
   chunkSize: 2 * 1024 * 1024,
 
   /**
-   * If `true`, the individual chunks of a file are being uploaded simultaneously.
+   * If `true`, the individual chunks of a file are uploaded simultaneously, at
+   * most `parallelUploads` of them at a time. Set a number to use a different
+   * limit, or `Infinity` to start every chunk at once.
    */
   parallelChunkUploads: false,
 

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -1801,12 +1801,111 @@ describe("Dropzone", function () {
         }));
 
       describe("chunking", function () {
+        // 6 bytes at chunkSize 1 gives 6 chunks; parallelUploads defaults to 2.
+        let startChunked = (overrides) => {
+          vi.spyOn(dropzone, "_uploadData").mockImplementation(() => {});
+          dropzone.options.chunking = true;
+          dropzone.options.chunkSize = 1;
+          Object.assign(dropzone.options, overrides);
+
+          let file = getMockFile("text/html", "chunked-file", ["abcdef"]);
+          dropzone.addFile(file);
+          return file;
+        };
+
+        let finishChunk = (file, index) => {
+          let chunk = file.upload.chunks[index];
+          chunk.xhr = { responseText: "ok", getAllResponseHeaders: () => "" };
+          file.upload.finishedChunkUpload(chunk, "ok");
+        };
+
+        describe("parallelChunkUploads", function () {
+          it("should start at most parallelUploads chunks when true", () =>
+            new Promise((done) => {
+              let file = startChunked({ parallelChunkUploads: true });
+
+              setTimeout(function () {
+                expect(file.upload.totalChunkCount).toEqual(6);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(2);
+                done();
+              }, 10);
+            }));
+
+          it("should start the remaining chunks as earlier ones finish", () =>
+            new Promise((done) => {
+              let file = startChunked({ parallelChunkUploads: true });
+
+              setTimeout(function () {
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(2);
+
+                // Each completion should release exactly one more chunk, until
+                // there are none left to start.
+                finishChunk(file, 0);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(3);
+                finishChunk(file, 1);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(4);
+                finishChunk(file, 2);
+                finishChunk(file, 3);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(6);
+
+                // All six started, so further completions start nothing new.
+                finishChunk(file, 4);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(6);
+                done();
+              }, 10);
+            }));
+
+          it("should treat a number as the limit", () =>
+            new Promise((done) => {
+              let file = startChunked({ parallelChunkUploads: 3 });
+
+              setTimeout(function () {
+                expect(file.upload.totalChunkCount).toEqual(6);
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(3);
+                done();
+              }, 10);
+            }));
+
+          it("should start every chunk at once when Infinity", () =>
+            new Promise((done) => {
+              startChunked({ parallelChunkUploads: Infinity });
+
+              setTimeout(function () {
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(6);
+                done();
+              }, 10);
+            }));
+
+          it("should start one chunk at a time when false", () =>
+            new Promise((done) => {
+              startChunked({ parallelChunkUploads: false });
+
+              setTimeout(function () {
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(1);
+                done();
+              }, 10);
+            }));
+
+          it("should never start fewer than one chunk", () =>
+            new Promise((done) => {
+              startChunked({ parallelChunkUploads: 0 });
+
+              setTimeout(function () {
+                expect(dropzone._uploadData).toHaveBeenCalledTimes(1);
+                done();
+              }, 10);
+            }));
+        });
+
         it("should slice on numeric boundaries when chunkSize is a string", () =>
           new Promise((done) => {
             vi.spyOn(dropzone, "_uploadData").mockImplementation(() => {});
 
             dropzone.options.chunking = true;
-            dropzone.options.parallelChunkUploads = true;
+            // Infinity so all three slices are handed over in one go and can
+            // be inspected together; the boundaries are what matter here, not
+            // the concurrency.
+            dropzone.options.parallelChunkUploads = Infinity;
             // Options read out of markup or JSON arrive as strings.
             dropzone.options.chunkSize = "2";
 


### PR DESCRIPTION
parallelChunkUploads: true started every chunk of a file simultaneously. Over HTTP/1.1 the browser queues most of them, but on HTTP/2 they are multiplexed and a large file arrives at the server as hundreds of concurrent requests. The reporter's words: "drastically reduces the io weight on the receiving end."

true now defers to parallelUploads, and a number sets its own limit. Nothing is lost by starting fewer: finishedChunkUpload already picks up the next unstarted chunk as earlier ones complete, so the only change is how many are in flight at a time. Infinity restores the old behaviour for anyone who wants it, which is why this is a minor rather than a patch.

Reworked from the original patch: the superseded loop is deleted rather than commented out, the count is clamped so a limit of 0 still starts one chunk, and the option's documentation now describes the three forms.

Also removes startedChunkCount, which was incremented but never read -- a counter someone began writing for exactly this and left behind.

Closes #2249