### PR TITLE
Add resizeTransparencyFill for images resized to a format without alpha

### DIFF
--- a/.changeset/resize-transparency-fill.md
+++ b/.changeset/resize-transparency-fill.md
@@ -1,0 +1,5 @@
+---
+"dropzone": minor
+---
+
+Add `resizeTransparencyFill`, the colour shown through transparent parts of a resized image. A transparent PNG resized to `image/jpeg` previously came out with black where it used to be see-through; set this to `"#fff"`, or any CSS colour, for a background instead. Defaults to `null`, which keeps the current behaviour.

--- a/.changeset/resize-transparency-fill.md
+++ b/.changeset/resize-transparency-fill.md
@@ -2,4 +2,4 @@
 "dropzone": minor
 ---
 
-Add `resizeTransparencyFill`, the colour shown through transparent parts of a resized image. A transparent PNG resized to `image/jpeg` previously came out with black where it used to be see-through; set this to `"#fff"`, or any CSS colour, for a background instead. Defaults to `null`, which keeps the current behaviour.
+Add `resizeTransparencyFill`, the color shown through transparent parts of a resized image. A transparent PNG resized to `image/jpeg` previously came out with black where it used to be see-through; set this to `"#fff"`, or any CSS color, for a background instead. Defaults to `null`, which keeps the current behavior.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -830,7 +830,7 @@ export default class Dropzone extends Emitter {
           resizeMimeType = file.type;
         }
         if (this.options.resizeTransparencyFill != null) {
-          // Painted *underneath* what has already been drawn, so the colour
+          // Painted *underneath* what has already been drawn, so the color
           // only shows through where the image is actually transparent. Doing
           // it here rather than before the draw keeps it off the preview
           // thumbnails, which are encoded as PNG and keep their transparency.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -1062,8 +1062,7 @@ export default class Dropzone extends Emitter {
   }
 
   _getFilesWithXhr(xhr) {
-    let files;
-    return (files = this.files.filter((file) => file.xhr === xhr).map((file) => file));
+    return this.files.filter((file) => file.xhr === xhr).map((file) => file);
   }
 
   // Cancels the file upload and sets the status to CANCELED
@@ -1920,7 +1919,6 @@ Dropzone.SUCCESS = "success";
 // Fixes a bug which squash image vertically while drawing into canvas for some images.
 // This is a bug in iOS6 devices. This function from https://github.com/stomita/ios-imagefile-megapixel
 let detectVerticalSquash = function (img) {
-  let iw = img.naturalWidth;
   let ih = img.naturalHeight;
   let canvas = document.createElement("canvas");
   canvas.width = 1;
@@ -2073,7 +2071,6 @@ class ExifRestore {
   }
 
   static decode64(input) {
-    let output = "";
     let chr1 = undefined;
     let chr2 = undefined;
     let chr3 = "";

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -829,6 +829,17 @@ export default class Dropzone extends Emitter {
         if (resizeMimeType == null) {
           resizeMimeType = file.type;
         }
+        if (this.options.resizeTransparencyFill != null) {
+          // Painted *underneath* what has already been drawn, so the colour
+          // only shows through where the image is actually transparent. Doing
+          // it here rather than before the draw keeps it off the preview
+          // thumbnails, which are encoded as PNG and keep their transparency.
+          let ctx = canvas.getContext("2d");
+          ctx.globalCompositeOperation = "destination-over";
+          ctx.fillStyle = this.options.resizeTransparencyFill;
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+        }
+
         let resizedDataURL = canvas.toDataURL(resizeMimeType, this.options.resizeQuality);
         if (resizeMimeType === "image/jpeg" || resizeMimeType === "image/jpg") {
           // Now add the original EXIF information

--- a/src/options.js
+++ b/src/options.js
@@ -152,8 +152,8 @@ let defaultOptions = {
   resizeMethod: "contain",
 
   /**
-   * The colour to show through transparent parts of a resized image, as any
-   * CSS colour. Formats without an alpha channel cannot store transparency, so
+   * The color to show through transparent parts of a resized image, as any
+   * CSS color. Formats without an alpha channel cannot store transparency, so
    * a transparent PNG resized to `image/jpeg` comes out with black where it
    * used to be see-through; setting this to `"#fff"` makes it white instead.
    *

--- a/src/options.js
+++ b/src/options.js
@@ -152,6 +152,18 @@ let defaultOptions = {
   resizeMethod: "contain",
 
   /**
+   * The colour to show through transparent parts of a resized image, as any
+   * CSS colour. Formats without an alpha channel cannot store transparency, so
+   * a transparent PNG resized to `image/jpeg` comes out with black where it
+   * used to be see-through; setting this to `"#fff"` makes it white instead.
+   *
+   * `null` leaves transparency alone, which only produces black once the image
+   * is encoded to a format that cannot represent it. This has no effect on the
+   * preview thumbnails, which are always PNG.
+   */
+  resizeTransparencyFill: null,
+
+  /**
    * The base that is used to calculate the **displayed** filesize. You can
    * change this to 1024 if you would rather display kibibytes, mebibytes,
    * etc... 1024 is technically incorrect, because `1024 bytes` are `1 kibibyte`

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -1390,6 +1390,91 @@ describe("Dropzone", function () {
         }));
     });
 
+    describe("resizeImage()", function () {
+      // Opaque blue across the top-left quarter, transparent everywhere else.
+      let transparentPng = () =>
+        new Promise((resolve) => {
+          let canvas = document.createElement("canvas");
+          canvas.width = canvas.height = 20;
+          let ctx = canvas.getContext("2d");
+          ctx.fillStyle = "#0000ff";
+          ctx.fillRect(0, 0, 10, 10);
+          canvas.toBlob(
+            (blob) => resolve(new File([blob], "transparent.png", { type: "image/png" })),
+            "image/png",
+          );
+        });
+
+      // Decode a blob or data URL and read one pixel back, positioned as a
+      // fraction so it does not matter what the resize produced.
+      let pixelAt = (source, fx, fy) =>
+        new Promise((resolve) => {
+          let img = document.createElement("img");
+          img.onload = function () {
+            let canvas = document.createElement("canvas");
+            canvas.width = img.width;
+            canvas.height = img.height;
+            let ctx = canvas.getContext("2d");
+            ctx.drawImage(img, 0, 0);
+            let x = Math.floor(img.width * fx);
+            let y = Math.floor(img.height * fy);
+            resolve(Array.from(ctx.getImageData(x, y, 1, 1).data));
+          };
+          img.src = typeof source === "string" ? source : URL.createObjectURL(source);
+        });
+
+      let resize = (file) =>
+        new Promise((done) => dropzone.resizeImage(file, 20, 20, "contain", done));
+
+      it("should show the fill through transparent areas when resizing to jpeg", async function () {
+        let file = await transparentPng();
+        dropzone.options.resizeMimeType = "image/jpeg";
+        dropzone.options.resizeTransparencyFill = "#ff0000";
+
+        let [r, g, b] = await pixelAt(await resize(file), 0.75, 0.75);
+        expect(r).toBeGreaterThan(200);
+        expect(g).toBeLessThan(60);
+        expect(b).toBeLessThan(60);
+      });
+
+      it("should leave transparency to turn black by default", async function () {
+        let file = await transparentPng();
+        dropzone.options.resizeMimeType = "image/jpeg";
+
+        // This is the behaviour being fixed, and it stays the default.
+        let [r, g, b] = await pixelAt(await resize(file), 0.75, 0.75);
+        expect(r).toBeLessThan(60);
+        expect(g).toBeLessThan(60);
+        expect(b).toBeLessThan(60);
+      });
+
+      it("should not paint over the image itself", async function () {
+        let file = await transparentPng();
+        dropzone.options.resizeMimeType = "image/jpeg";
+        dropzone.options.resizeTransparencyFill = "#ff0000";
+
+        // The opaque corner must survive: the fill goes underneath.
+        let [r, g, b] = await pixelAt(await resize(file), 0.25, 0.25);
+        expect(b).toBeGreaterThan(200);
+        expect(r).toBeLessThan(60);
+        expect(g).toBeLessThan(60);
+      });
+
+      it("should leave preview thumbnails transparent", async function () {
+        let file = await transparentPng();
+        dropzone.options.resizeTransparencyFill = "#ff0000";
+
+        // Thumbnails are always encoded as PNG, so they keep their alpha and
+        // the fill must not reach them.
+        let dataUrl = await new Promise((done) =>
+          dropzone.createThumbnail(file, 20, 20, "contain", true, (url) => done(url)),
+        );
+
+        let alpha = (await pixelAt(dataUrl, 0.75, 0.75))[3];
+        expect(alpha).toBe(0);
+      });
+    });
+
     describe("uploadFiles()", function () {
       let requests;
 

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -237,7 +237,7 @@ describe("Dropzone", function () {
 
     it("should create a .dz-message element", function () {
       let element = Dropzone.createElement('<form class="dropzone" action="/"></form>');
-      let dropzone = new Dropzone(element, {
+      new Dropzone(element, {
         clickable: true,
         acceptParameter: null,
         acceptedMimeTypes: null,
@@ -250,7 +250,7 @@ describe("Dropzone", function () {
       let msg = Dropzone.createElement('<div class="dz-message">TEST</div>');
       element.appendChild(msg);
 
-      let dropzone = new Dropzone(element, {
+      new Dropzone(element, {
         clickable: true,
         acceptParameter: null,
         acceptedMimeTypes: null,
@@ -1221,9 +1221,8 @@ describe("Dropzone", function () {
         it("should properly queue the thumbnail creation", () =>
           new Promise((done) => {
             let ct_callback;
-            let doneFunction;
 
-            dropzone.accept = (file, done) => (doneFunction = done);
+            dropzone.accept = (file, done) => {};
             dropzone.processFile = function () {};
             dropzone.uploadFile = function () {};
 


### PR DESCRIPTION
A transparent PNG resized to image/jpeg comes out with black wherever it used to be see-through, because JPEG has no alpha channel and the canvas starts out transparent.

Reworked from the original patch in four ways:

Renamed from canvasFill. A canvas is an implementation detail nobody using the option has to know about, and "fill" alone says neither what is filled nor when. The new name sits with resizeWidth, resizeMimeType and resizeQuality, which is the family it belongs to.

Narrowed to the resize path. The original filled inside drawImageIOSFix, which both paths share, so it also painted behind every preview thumbnail. Thumbnails are always encoded as PNG and keep their transparency, so they never had the problem -- there is a test pinning that they stay untouched.

Default is null rather than "white". Defaulting to a colour would have put a white box behind every transparent preview for every existing user.

Composited with destination-over after the draw instead of filling before it, so the colour only shows through actually transparent pixels rather than sitting behind the whole image. That also means no public signature moves: the original threaded a new positional argument through createThumbnail, createThumbnailFromUrl and resizeImage, ahead of the callback, which would have broken every existing caller of three documented methods.

Closes #2241