### PR TITLE
Give the hidden file input an aria-label

### DIFF
--- a/.changeset/hidden-input-aria-label.md
+++ b/.changeset/hidden-input-aria-label.md
@@ -1,0 +1,5 @@
+---
+"dropzone": patch
+---
+
+Give the hidden file input an `aria-label`, so accessibility auditors stop reporting it as an unlabelled input. This does not change anything for screen reader users: browsers leave `visibility: hidden` elements out of the accessibility tree entirely, and the `.dz-button` carrying `dictDefaultMessage` remains the control they interact with.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -228,6 +228,14 @@ export default class Dropzone extends Emitter {
         // Making sure that no one can "tab" into this field.
         this.hiddenFileInput.setAttribute("tabindex", "-1");
 
+        // Auditors such as WAVE report this input as unlabelled. It never
+        // actually reaches assistive technology -- browsers drop
+        // `visibility: hidden` elements from the accessibility tree entirely,
+        // and the .dz-button carrying `dictDefaultMessage` is the control a
+        // screen reader sees. The name is here to clear the audit, which a lot
+        // of people are obliged to pass.
+        this.hiddenFileInput.setAttribute("aria-label", "hidden file upload");
+
         // Not setting `display="none"` because some browsers don't accept clicks
         // on elements that aren't displayed.
         this.hiddenFileInput.style.visibility = "hidden";

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -209,6 +209,12 @@ describe("Dropzone", function () {
                   expect(dropzone.hiddenFileInput.tabIndex).toBe(-1);
                 });
 
+                it("should carry an aria-label for automated auditors", function () {
+                  expect(dropzone.hiddenFileInput.getAttribute("aria-label")).toBe(
+                    "hidden file upload",
+                  );
+                });
+
                 it("should use the acceptParameter", () =>
                   expect(dropzone.hiddenFileInput.getAttribute("accept")).toBe("audio/*,video/*"));
 


### PR DESCRIPTION
Picks up #2214 by @colaclanth, whose motivation was clearing the errors that auditors like WAVE report for the unlabelled input Dropzone creates for click-to-select.

### What this actually does

It is worth stating plainly, because the obvious reading is wrong: **this changes nothing for screen reader users.**

I dumped Chromium's accessibility tree for a default dropzone. It contains eight nodes, and the file input is not among them — not even as an ignored node:

```
role=RootWebArea    name="Dropzone Test"
role=none           ignored=true  reasons=uninteresting
role=none           ignored=true  reasons=uninteresting
role=form           name=""
role=generic        name=""
role=button         name="Drop files here to upload"
role=StaticText     name="Drop files here to upload"
role=InlineTextBox  name="Drop files here to upload"
```

Adding the `aria-label` and re-dumping produces an identical tree. Browsers drop `visibility: hidden` subtrees from the accessibility tree entirely, so no name on that element can reach assistive technology. What AT sees is the `.dz-button` carrying `dictDefaultMessage` — which is the control that opens the file dialog anyway.

So this clears an audit finding that many users are contractually obliged to pass. It is not an accessibility improvement, and the changeset says so rather than claiming credit for one.

### Decisions

- **One attribute, no new option.** A string that nothing can read does not need translating.
- **Taken over #1972**, which made the same change through the `ariaLabel` property instead of `setAttribute`; that author noted Firefox lacked support for it at the time. #1972 is closed pointing here.

### Verification

`format:check`, `lint` (0 warnings), `build`, 179 unit tests and both e2e specs pass. The new test asserts the attribute on both clickable dropzone configurations.

Closes #2214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
