### PR TITLE
Report the real contents of a dropped folder in addedfiles

### DIFF
--- a/.changeset/directory-drop-addedfiles.md
+++ b/.changeset/directory-drop-addedfiles.md
@@ -1,0 +1,9 @@
+---
+"dropzone": minor
+---
+
+`addedfiles` now reports the files found inside a dropped folder. It previously received `e.dataTransfer.files`, which holds the folder entries rather than their contents, so anyone counting dropped files got the wrong answer for folders.
+
+**This changes when the event fires.** Reading a folder is asynchronous, so on browsers that support folder drops — all of them — `addedfiles` is now emitted once the walk finishes, after the individual `addedfile` events, instead of synchronously at the end of the drop handler. Listeners still receive the event; only the timing moves.
+
+Also adds an `emptyfolder` event, emitted with the folder's path when a dropped folder turns out to contain nothing at all.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -44,6 +44,7 @@ export default class Dropzone extends Emitter {
       "maxfilesexceeded",
       "maxfilesreached",
       "queuecomplete",
+      "emptyfolder",
     ];
 
     this.prototype._thumbnailQueue = [];
@@ -563,7 +564,6 @@ export default class Dropzone extends Emitter {
     this.emit("drop", e);
 
     // Convert the FileList to an Array
-    // This is necessary for IE11
     let files = [];
     for (let i = 0; i < e.dataTransfer.files.length; i++) {
       files[i] = e.dataTransfer.files[i];
@@ -573,11 +573,16 @@ export default class Dropzone extends Emitter {
     if (files.length) {
       let { items } = e.dataTransfer;
       if (items && items.length && items[0].webkitGetAsEntry != null) {
-        // The browser supports dropping of folders, so handle items instead of files
-        this._addFilesFromItems(items);
-      } else {
-        this.handleFiles(files);
+        // The browser supports dropping of folders, so the items get walked
+        // rather than the files. `e.dataTransfer.files` holds the folder
+        // entries themselves, not what is inside them, so `addedfiles` waits
+        // for the walk and reports what was actually added.
+        this._addFilesFromItems(items).then((addedFiles) => {
+          this.emit("addedfiles", addedFiles);
+        });
+        return;
       }
+      this.handleFiles(files);
     }
 
     this.emit("addedfiles", files);
@@ -604,67 +609,103 @@ export default class Dropzone extends Emitter {
 
   // When a folder is dropped (or files are pasted), items must be handled
   // instead of files.
+  //
+  // Resolves with every file that was added, so `drop` can report the real
+  // contents of a dropped folder rather than the folder entry itself.
   _addFilesFromItems(items) {
-    return (() => {
-      let result = [];
-      for (let item of items) {
-        var entry;
-        if (item.webkitGetAsEntry != null && (entry = item.webkitGetAsEntry())) {
-          if (entry.isFile) {
-            result.push(this.addFile(item.getAsFile()));
-          } else if (entry.isDirectory) {
-            // Append all files from that directory to files
-            result.push(this._addFilesFromDirectory(entry, entry.name));
-          } else {
-            result.push(undefined);
-          }
-        } else if (item.getAsFile != null) {
-          if (item.kind == null || item.kind === "file") {
-            result.push(this.addFile(item.getAsFile()));
-          } else {
-            result.push(undefined);
-          }
-        } else {
-          result.push(undefined);
+    let files = [];
+    let directories = [];
+
+    for (let item of items) {
+      let entry = item.webkitGetAsEntry != null ? item.webkitGetAsEntry() : null;
+
+      if (entry) {
+        if (entry.isFile) {
+          let file = item.getAsFile();
+          this.addFile(file);
+          files.push(file);
+        } else if (entry.isDirectory) {
+          // Append all files from that directory to files
+          directories.push(this._addFilesFromDirectory(entry, entry.name));
         }
+      } else if (item.getAsFile != null && (item.kind == null || item.kind === "file")) {
+        let file = item.getAsFile();
+        this.addFile(file);
+        files.push(file);
       }
-      return result;
-    })();
+    }
+
+    return Promise.all(directories).then((fromDirectories) => files.concat(...fromDirectories));
   }
 
-  // Goes through the directory, and adds each file it finds recursively
+  // Goes through the directory, and adds each file it finds recursively.
+  // Resolves with the files that were added.
   _addFilesFromDirectory(directory, path) {
     let dirReader = directory.createReader();
 
-    let errorHandler = (error) => __guardMethod__(console, "log", (o) => o.log(error));
+    return new Promise((resolve) => {
+      let pending = [];
+      let entryCount = 0;
 
-    var readEntries = () => {
-      return dirReader.readEntries((entries) => {
-        if (entries.length > 0) {
-          for (let entry of entries) {
-            if (entry.isFile) {
-              entry.file((file) => {
-                if (this.options.ignoreHiddenFiles && file.name.substring(0, 1) === ".") {
-                  return;
-                }
-                file.fullPath = `${path}/${file.name}`;
-                return this.addFile(file);
-              });
-            } else if (entry.isDirectory) {
-              this._addFilesFromDirectory(entry, `${path}/${entry.name}`);
+      // Every pending entry resolves with an array, so a single concat
+      // flattens files and nested directories together.
+      let settle = () => Promise.all(pending).then((results) => resolve([].concat(...results)));
+
+      let errorHandler = (error) => {
+        __guardMethod__(console, "log", (o) => o.log(error));
+        // Settle instead of hanging: a directory that cannot be read must not
+        // stop `addedfiles` from ever firing.
+        settle();
+      };
+
+      let readEntries = () =>
+        dirReader.readEntries((entries) => {
+          if (entries.length > 0) {
+            entryCount += entries.length;
+
+            for (let entry of entries) {
+              if (entry.isFile) {
+                pending.push(
+                  new Promise((resolveEntry) =>
+                    entry.file(
+                      (file) => {
+                        if (this.options.ignoreHiddenFiles && file.name.substring(0, 1) === ".") {
+                          resolveEntry([]);
+                          return;
+                        }
+                        file.fullPath = `${path}/${file.name}`;
+                        this.addFile(file);
+                        resolveEntry([file]);
+                      },
+                      // Same reasoning as errorHandler: never leave it pending.
+                      () => resolveEntry([]),
+                    ),
+                  ),
+                );
+              } else if (entry.isDirectory) {
+                pending.push(this._addFilesFromDirectory(entry, `${path}/${entry.name}`));
+              }
             }
+
+            // Recursively call readEntries() again, since browser only handle
+            // the first 100 entries.
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/DirectoryReader#readEntries
+            readEntries();
+            return null;
           }
 
-          // Recursively call readEntries() again, since browser only handle
-          // the first 100 entries.
-          // See: https://developer.mozilla.org/en-US/docs/Web/API/DirectoryReader#readEntries
-          readEntries();
-        }
-        return null;
-      }, errorHandler);
-    };
+          // Counting every entry rather than only the files, so a folder that
+          // holds nothing but other folders is not reported as empty.
+          if (entryCount === 0) {
+            this.emit("emptyfolder", path);
+          }
 
-    return readEntries();
+          settle();
+          return null;
+        }, errorHandler);
+
+      readEntries();
+    });
   }
 
   // If `done()` is called without argument the file is accepted

--- a/src/options.js
+++ b/src/options.js
@@ -784,6 +784,12 @@ let defaultOptions = {
   queuecomplete() {},
 
   addedfiles() {},
+
+  /**
+   * Called when a dropped folder turns out to have nothing in it at all.
+   * Receives the folder's path.
+   */
+  emptyfolder() {},
 };
 
 export default defaultOptions;

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -1389,6 +1389,125 @@ describe("Dropzone", function () {
         }));
     });
 
+    describe("dropping directories", function () {
+      // Stand-ins for the FileSystem entries a real drop hands over. Both
+      // callbacks fire asynchronously, as the browser's do.
+      let fileEntry = (name) => ({
+        isFile: true,
+        isDirectory: false,
+        name,
+        file: (onSuccess) =>
+          Promise.resolve().then(() => onSuccess(new File(["x"], name, { type: "text/plain" }))),
+      });
+
+      let dirEntry = (name, children = []) => ({
+        isFile: false,
+        isDirectory: true,
+        name,
+        createReader() {
+          let handed = false;
+          return {
+            // A browser returns a batch, then an empty array to signal the end.
+            readEntries(onSuccess) {
+              let batch = handed ? [] : children;
+              handed = true;
+              Promise.resolve().then(() => onSuccess(batch));
+            },
+          };
+        },
+      });
+
+      // dataTransfer.files holds one entry per dropped item, folders included,
+      // which is exactly why it cannot say what was added.
+      let dropOf = (...entries) => ({
+        dataTransfer: {
+          files: entries.map((e) => new File(["x"], e.name)),
+          items: entries.map((e) => ({
+            kind: "file",
+            webkitGetAsEntry: () => e,
+            getAsFile: () => new File(["x"], e.name),
+          })),
+        },
+      });
+
+      beforeEach(function () {
+        dropzone.options.autoProcessQueue = false;
+      });
+
+      it("should report the files inside a dropped folder, not the folder", () =>
+        new Promise((done) => {
+          dropzone.on("addedfiles", function (files) {
+            expect(files.map((f) => f.name)).toEqual(["a.txt", "b.txt"]);
+            done();
+          });
+
+          dropzone.drop(dropOf(dirEntry("photos", [fileEntry("a.txt"), fileEntry("b.txt")])));
+        }));
+
+      it("should emit addedfiles after each addedfile", () =>
+        new Promise((done) => {
+          let order = [];
+          dropzone.on("addedfile", (file) => order.push(`one:${file.name}`));
+          dropzone.on("addedfiles", function () {
+            order.push("all");
+            expect(order).toEqual(["one:a.txt", "one:b.txt", "all"]);
+            done();
+          });
+
+          dropzone.drop(dropOf(dirEntry("photos", [fileEntry("a.txt"), fileEntry("b.txt")])));
+        }));
+
+      it("should walk nested folders and record the full path", () =>
+        new Promise((done) => {
+          dropzone.on("addedfiles", function (files) {
+            expect(files.map((f) => f.fullPath)).toEqual(["outer/a.txt", "outer/inner/b.txt"]);
+            done();
+          });
+
+          dropzone.drop(
+            dropOf(
+              dirEntry("outer", [fileEntry("a.txt"), dirEntry("inner", [fileEntry("b.txt")])]),
+            ),
+          );
+        }));
+
+      it("should still skip hidden files", () =>
+        new Promise((done) => {
+          dropzone.on("addedfiles", function (files) {
+            expect(files.map((f) => f.name)).toEqual(["visible.txt"]);
+            done();
+          });
+
+          dropzone.drop(
+            dropOf(dirEntry("photos", [fileEntry(".hidden"), fileEntry("visible.txt")])),
+          );
+        }));
+
+      it("should emit emptyfolder for a folder with nothing in it", () =>
+        new Promise((done) => {
+          dropzone.on("emptyfolder", function (path) {
+            expect(path).toBe("nothing-here");
+            done();
+          });
+
+          dropzone.drop(dropOf(dirEntry("nothing-here", [])));
+        }));
+
+      it("should not call a folder empty when it only holds other folders", () =>
+        new Promise((done) => {
+          let reported = [];
+          dropzone.on("emptyfolder", (path) => reported.push(path));
+          dropzone.on("addedfiles", function () {
+            // Only the leaf is genuinely empty. Counting files alone would
+            // have reported "outer" as well.
+            expect(reported).toEqual(["outer/inner"]);
+            done();
+          });
+
+          dropzone.drop(dropOf(dirEntry("outer", [dirEntry("inner", [])])));
+        }));
+    });
+
     describe("resizeImage()", function () {
       // Opaque blue across the top-left quarter, transparent everywhere else.
       let transparentPng = () =>


### PR DESCRIPTION
Takes #1995 by @qstiegler together with #2325 by @CyBot, since both rewrite the same directory walk.

### The bug

`addedfiles` was emitted with `e.dataTransfer.files`. For a folder drop that array holds the **folder entries**, not the files inside them, so anyone using the event to count what a user dropped got the wrong answer. It also fired *before* the `addedfile` events for those contents, which is backwards for an event meant to summarise them.

### The breaking part, stated plainly

Reading a folder is asynchronous, so fixing the payload necessarily moves the event. `addedfiles` now fires once the walk finishes, after the individual `addedfile` events, rather than synchronously at the end of the drop handler. Every browser that supports folder drops takes this path, so **the timing changes for all drops**, not only folder ones. Listeners still fire and still receive the files; only the moment moves.

That is the reason this is a minor rather than a patch. If you would rather it not move at all, the alternative is to stay synchronous when no folders are present and go async only when they are — that keeps today's timing for the common case at the cost of the event meaning something slightly different depending on what was dropped. I went for consistent semantics; happy to switch.

Promises rather than nested callbacks: Dropzone 6 already dropped IE, the build targets `es2017`, and nothing here is polyfilled or down-levelled.

### emptyfolder, with a correction

#2325 adds an `emptyfolder` event carrying the folder's path. As written it counted only files, so a folder containing nothing but other folders reported itself as empty. This counts every entry instead. There is a test that fails against the original version:

```
× should not call a folder empty when it only holds other folders
```

### Two things that fell out of the rewrite

- `entry.file()` and `readEntries()` now have error callbacks that settle the promise instead of leaving it pending. Previously a folder that could not be read would simply stop `addedfiles` from ever firing.
- `item.getAsFile()` is called once per item rather than twice, which had been producing two distinct `File` objects for the same drop.

### Verification

183 unit tests (six new), both e2e specs, `lint` at 0 warnings, `format:check` and `build` clean. The new tests use stand-ins for the FileSystem entry API whose callbacks fire asynchronously, as the browser's do. Reverting the payload fix fails five of them; reverting the entry counting fails the sixth.

Closes #1995
Closes #2325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
