### PR TITLE
Associate the hidden file input with its form

### DIFF
--- a/.changeset/hidden-input-form-attribute.md
+++ b/.changeset/hidden-input-form-attribute.md
@@ -1,0 +1,5 @@
+---
+"dropzone": patch
+---
+
+Associate the hidden file input with its form. The input is appended to `hiddenInputContainer` (the body by default), so it sits outside the form it belongs to and several dropzones on one page produce indistinguishable inputs. It now carries a `form` attribute when the dropzone is a form, or sits inside one, and that form has an id. The input has no `name`, so this does not change what a native submit sends — but it does mean the input now appears in `form.elements`.

--- a/src/dropzone.js
+++ b/src/dropzone.js
@@ -245,6 +245,21 @@ export default class Dropzone extends Emitter {
         this.hiddenFileInput.style.left = "0";
         this.hiddenFileInput.style.height = "0";
         this.hiddenFileInput.style.width = "0";
+        // The input is appended to `hiddenInputContainer` -- the body by
+        // default -- so it ends up outside whatever form it belongs to, and
+        // with several dropzones on a page nothing tells one input from
+        // another. Associating it with the form gives tooling something to go
+        // on.
+        //
+        // Only ever pointed at a real <form>: the attribute has to reference
+        // one, and aiming it at anything else leaves the input owned by no
+        // form at all. The input carries no `name`, so this cannot change what
+        // a native submit sends.
+        let ownerForm = this.element.closest("form");
+        if (ownerForm && ownerForm.id) {
+          this.hiddenFileInput.setAttribute("form", ownerForm.id);
+        }
+
         Dropzone.getElement(this.options.hiddenInputContainer, "hiddenInputContainer").appendChild(
           this.hiddenFileInput,
         );

--- a/test/unit-tests/all.js
+++ b/test/unit-tests/all.js
@@ -267,6 +267,73 @@ describe("Dropzone", function () {
     });
   });
 
+  describe("hidden input form association", function () {
+    let dropzones = [];
+    let elements = [];
+
+    let attach = (html, selector) => {
+      let element = Dropzone.createElement(html);
+      document.body.appendChild(element);
+      elements.push(element);
+
+      let dropzone = new Dropzone(selector ? element.querySelector(selector) : element, {
+        url: "/url",
+      });
+      dropzones.push(dropzone);
+      return dropzone;
+    };
+
+    afterEach(function () {
+      for (let dropzone of dropzones) dropzone.destroy();
+      for (let element of elements) element.parentNode.removeChild(element);
+      dropzones = [];
+      elements = [];
+    });
+
+    it("should point at the form when the dropzone is one", function () {
+      let dropzone = attach('<form id="upload-form" class="dropzone"></form>');
+      expect(dropzone.hiddenFileInput.getAttribute("form")).toBe("upload-form");
+    });
+
+    it("should point at an ancestor form", function () {
+      // The input is appended to the body, so it is outside this form.
+      let dropzone = attach('<form id="outer-form"><div class="inner"></div></form>', ".inner");
+      expect(dropzone.hiddenFileInput.getAttribute("form")).toBe("outer-form");
+    });
+
+    it("should not set the attribute when there is no form", function () {
+      let dropzone = attach('<div id="plain-dropzone"></div>');
+      expect(dropzone.hiddenFileInput.hasAttribute("form")).toBe(false);
+    });
+
+    it("should not point at an element that is not a form", function () {
+      // The element has an id, but `form` must reference a <form>; pointing it
+      // at a div would leave the input owned by no form at all.
+      let dropzone = attach('<div id="not-a-form"></div>');
+      expect(dropzone.hiddenFileInput.getAttribute("form")).toBe(null);
+    });
+
+    it("should not set the attribute when the form has no id", function () {
+      let dropzone = attach('<form class="dropzone"></form>');
+      expect(dropzone.hiddenFileInput.hasAttribute("form")).toBe(false);
+    });
+
+    it("should keep the association when the input is recreated", () =>
+      new Promise((done) => {
+        let dropzone = attach('<form id="recreated-form" class="dropzone"></form>');
+        let first = dropzone.hiddenFileInput;
+
+        // Selecting a file swaps the input out for a fresh one.
+        first.dispatchEvent(new Event("change"));
+
+        setTimeout(function () {
+          expect(dropzone.hiddenFileInput).not.toBe(first);
+          expect(dropzone.hiddenFileInput.getAttribute("form")).toBe("recreated-form");
+          done();
+        }, 10);
+      }));
+  });
+
   describe("options", function () {
     let element = null;
     let dropzone = null;


### PR DESCRIPTION
Picks up #2301 by @bancer, for #2300.

### The problem

The hidden input is appended to `hiddenInputContainer` — the body by default — so it lands outside whatever form it belongs to. With several dropzones on a page you get several identical `<input class="dz-hidden-input">` elements at the end of the document with nothing to tell them apart. The reporter hit this driving Dropzone from TestCafe.

### What changed from the original patch

It set `form` to `this.element.id` unconditionally. Three problems:

- The `form` attribute **must reference a `<form>`**. Dropzones are usually attached to a div, so this pointed the attribute at a non-form, which leaves the input owned by no form at all — worse than not setting it.
- It wrote `form=""` whenever the element had no id.
- It ignored the case the issue actually describes, a dropzone *inside* a form.

This resolves the nearest ancestor form with `closest()` — which covers both `<form class="dropzone">` and a div nested in a form — and sets the attribute only when that form has an id.

### Safety

The input has **no `name`**, so it is never submitted and this cannot change what a native submit sends. Two things do change, both harmless: the input now appears in `form.elements`, and `form.reset()` will clear it — its value is unused after the `change` event, and the input is replaced on every selection anyway. There's a test covering that the association survives that replacement.

### Verification

191 unit tests (six new), both e2e specs, `lint` at 0 warnings, `format:check` and `build` clean.

Running the suite against the original patch fails four of the six:

```
× should point at an ancestor form
× should not set the attribute when there is no form
× should not point at an element that is not a form
× should not set the attribute when the form has no id
```

Removing the change entirely fails the other three.

Closes #2300
Closes #2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
