### PR TITLE
Fix the dead links and remove what is left of Dropzone Plus

### DIFF
--- a/.changeset/fix-homepage-link.md
+++ b/.changeset/fix-homepage-link.md
@@ -1,0 +1,5 @@
+---
+"dropzone": patch
+---
+
+Point `homepage` at `https://www.dropzone.dev/`. It referenced `/js`, a route that only ever redirected to the front page and no longer exists, so the homepage link on npm was a 404.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use the standalone files like this:
 
 ---
 
-- [📚 Full documentation](https://docs.dropzone.dev)
+- [📚 Full documentation](https://www.dropzone.dev/docs/)
 - [⚙️ `src/options.js`](https://github.com/enyo/dropzone/blob/main/src/options.js)
   for all available options
 

--- a/apps/docs/docs/getting-started/installation/index.md
+++ b/apps/docs/docs/getting-started/installation/index.md
@@ -6,7 +6,5 @@ There are two ways to add Dropzone to your projects. If you are using a package 
 
 Dropzone.js does not handle your file uploads on the **server**. You have to implement the code to receive and store the file yourself. See the section [Server side implementation](../setup/server-side-implementation.md) for more information.
 
-If you're looking for an out-of-the-box solution, consider using [**Dropzone Plus**](https://www.dropzone.dev/plus).
-
 :::
 

--- a/apps/website/static/bootstrap.html
+++ b/apps/website/static/bootstrap.html
@@ -288,7 +288,7 @@
 
       <p>
         For a complete understanding of how Dropzone.js works please see the
-        <a href="https://docs.dropzone.dev/configuration/theming">docs for Dropzone theming</a>.
+        <a href="https://www.dropzone.dev/docs/configuration/theming">docs for Dropzone theming</a>.
       </p>
 
       <p>

--- a/apps/website/static/manifest.webmanifest
+++ b/apps/website/static/manifest.webmanifest
@@ -1,11 +1,11 @@
 {
-  "name": "Dropzone Plus",
+  "name": "Dropzone.js",
   "short_name": "Dropzone",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#0175C2",
   "theme_color": "#0175C2",
-  "description": "A form endpoint service.",
+  "description": "Dropzone.js is an open source library that provides beautiful and easy to use drag'n'drop file uploads with image previews.",
   "orientation": "portrait-primary",
   "prefer_related_applications": false,
   "icons": [

--- a/packages/dropzone/composer.json
+++ b/packages/dropzone/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "enyo/dropzone",
   "description": "Handles drag and drop of files for you.",
-  "homepage": "https://www.dropzone.dev/js",
+  "homepage": "https://www.dropzone.dev/",
   "keywords": [
     "dragndrop",
     "drag and drop",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -8,7 +8,7 @@
     "file upload",
     "upload"
   ],
-  "homepage": "https://www.dropzone.dev/js",
+  "homepage": "https://www.dropzone.dev/",
   "bugs": {
     "url": "https://github.com/enyo/dropzone/issues",
     "email": "m@tias.me"


### PR DESCRIPTION
Several links in the repository point at pages that no longer exist.

## `homepage` was a 404

Both `packages/dropzone/package.json` and `packages/dropzone/composer.json` set `homepage` to `https://www.dropzone.dev/js`. That route only ever redirected to the front page, and it was removed along with the other redirect-only routes during the SvelteKit migration. It is the link npmjs.com and packagist.org show as the package homepage, so it is a live 404 on both registries today. Both now point at `https://www.dropzone.dev/`.

A changeset is included: the pending 6.2.1 changeset says "Nothing else about the package changed", which this would otherwise make untrue.

## The docs moved off GitBook

`docs.dropzone.dev` still serves GitBook. The documentation now lives in this repository and is served at `/docs`, so the two remaining references follow it:

| file | was | now |
| --- | --- | --- |
| `README.md` | `https://docs.dropzone.dev` | `https://www.dropzone.dev/docs/` |
| `apps/website/static/bootstrap.html` | `https://docs.dropzone.dev/configuration/theming` | `https://www.dropzone.dev/docs/configuration/theming` |

All three targets were checked against the deployed site and return 200.

## Dropzone Plus is gone

The product no longer exists. The installation page recommended it as an out-of-the-box alternative and linked to `/plus`, another of the removed redirect routes. The whole sentence is removed rather than just the link, since it says nothing without it.

Removing it surfaced a second leftover: `apps/website/static/manifest.webmanifest` was still Plus's manifest, so installing the site as a web app announced it as **"Dropzone Plus — A form endpoint service."** That one is live, not dead — `app.html` links it and all the icons it names exist. Its `name` and `description` now match the site.

Its colours are deliberately untouched: `#0175C2` appears nowhere else in the site, but choosing what replaces it is a design decision rather than a mechanical one. `app.html` also still carries `<meta name="apple-mobile-web-app-title" content="client">`, which looks like scaffolding, and is left for the same reason.

## One thing this does not fix

**Packagist reads a different `composer.json`.** The release sync copies only `package.json` and `CHANGELOG.md` from this repository into the `dropzone-packagist` mirror, so the mirror keeps its own `composer.json` — and that is the one Packagist actually reads. Fixed separately in enyo/dropzone-packagist@4c2308d.