### PR TITLE
Drop the emoji from the documentation titles

### DIFF
--- a/apps/docs/docs/configuration/basics/index.md
+++ b/apps/docs/docs/configuration/basics/index.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ⚙ Basics
+# Basics
 
 In this section we'll co over the fundamentals of configuring Dropzones.
 

--- a/apps/docs/docs/configuration/events.md
+++ b/apps/docs/docs/configuration/events.md
@@ -1,4 +1,4 @@
-# 📞 Events
+# Events
 
 Dropzone triggers events when processing files, to which you can register easily, by calling `.on(eventName, callbackFunction)` on your Dropzone **instance:**
 

--- a/apps/docs/docs/configuration/theming.md
+++ b/apps/docs/docs/configuration/theming.md
@@ -1,4 +1,4 @@
-# 💅 Theming
+# Theming
 
 If you want to theme your Dropzone to look fully customized, in most cases you can simply replace the preview HTML template, adapt your CSS, and maybe create a few additional event listeners.
 

--- a/apps/docs/docs/configuration/tutorials/index.md
+++ b/apps/docs/docs/configuration/tutorials/index.md
@@ -1,3 +1,3 @@
-# 🤓 Tutorials
+# Tutorials
 
 In this section you'll learn how to do more complex things with Dropzone.

--- a/apps/docs/docs/getting-started/installation/index.md
+++ b/apps/docs/docs/getting-started/installation/index.md
@@ -1,4 +1,4 @@
-# ⏬ Installation
+# Installation
 
 There are two ways to add Dropzone to your projects. If you are using a package manager please refer to the [npm-or-yarn.md](npm-or-yarn.md "mention")section. If you simply want to use Dropzone without any bundler or package manager, please refer to the [stand-alone.md](stand-alone.md "mention")section.
 

--- a/apps/docs/docs/getting-started/setup/index.md
+++ b/apps/docs/docs/getting-started/setup/index.md
@@ -2,7 +2,7 @@
 description: How to setup a Dropzone on your website.
 ---
 
-# ✅ Setup
+# Setup
 
 After you've [installed Dropzone](../installation/) there are two ways to setup Dropzone. The easiest way is to let Dropzone auto discover your forms, and attach the drag and drop events automatically. For that, you simply need to provide a class to your form. This is called the **declarative** setup.
 

--- a/apps/docs/docs/index.md
+++ b/apps/docs/docs/index.md
@@ -3,7 +3,7 @@ slug: /
 description: The documentation for the JavaScript library Dropzone.
 ---
 
-# 👋 Introduction
+# Introduction
 
 Dropzone is a simple JavaScript library that helps you add file drag and drop functionality to your web forms. It is one of the most popular drag and drop library on the web and is used by millions of people.
 

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -3,14 +3,14 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   docs: [
-    { type: "doc", id: "index", label: "👋 Introduction" },
+    { type: "doc", id: "index", label: "Introduction" },
     {
       type: "category",
       label: "Getting Started",
       items: [
         {
           type: "category",
-          label: "⏬ Installation",
+          label: "Installation",
           link: { type: "doc", id: "getting-started/installation/index" },
           items: [
             "getting-started/installation/npm-or-yarn",
@@ -20,7 +20,7 @@ const sidebars = {
         },
         {
           type: "category",
-          label: "✅ Setup",
+          label: "Setup",
           link: { type: "doc", id: "getting-started/setup/index" },
           items: [
             "getting-started/setup/declarative",
@@ -37,7 +37,7 @@ const sidebars = {
       items: [
         {
           type: "category",
-          label: "⚙️ Basics",
+          label: "Basics",
           link: { type: "doc", id: "configuration/basics/index" },
           items: [
             "configuration/basics/configuration-options",
@@ -50,7 +50,7 @@ const sidebars = {
         "configuration/theming",
         {
           type: "category",
-          label: "🤓 Tutorials",
+          label: "Tutorials",
           link: { type: "doc", id: "configuration/tutorials/index" },
           items: ["configuration/tutorials/combine-form-data-with-files"],
         },


### PR DESCRIPTION
The emoji came over with the GitBook import, where they were part of the page titles rather than decoration added here.

They appeared in two places:

- **seven page headings** — Introduction, Installation, Setup, Basics, Events, Theming, Tutorials
- **five hardcoded `sidebars.js` labels** — the rest of the sidebar derives its label from the heading, so `events` and `theming` were fixed by the heading change alone

Only some pages had them, so the sidebar read as a mix of decorated and plain entries, and the emoji led the browser tab title and search results too.

## Nothing structural changes

Slugs come from file paths rather than titles, so all 22 URLs are unchanged. The build passes with `onBrokenLinks` and `onBrokenAnchors` set to `throw`, and no emoji survive anywhere in the built HTML.

The two remaining non-ASCII characters in the docs are the `✔` and `✘` inside the default preview template in `configuration/basics/layout.md`. Those are markup rather than decoration and are deliberately untouched.