### PR TITLE
Replace the npm-or-yarn page with a Package manager page

### DIFF
--- a/apps/docs/docs/getting-started/installation/index.md
+++ b/apps/docs/docs/getting-started/installation/index.md
@@ -1,6 +1,6 @@
 # ⏬ Installation
 
-There are two ways to add Dropzone to your projects. If you are using a package manager please refer to the [npm-or-yarn.md](npm-or-yarn.md "mention")section. If you simply want to use Dropzone without any bundler or package manager, please refer to the [stand-alone.md](stand-alone.md "mention")section.
+There are two ways to add Dropzone to your projects. If you are using a package manager please refer to the [Package manager](package-manager.md) section. If you simply want to use Dropzone without any bundler or package manager, please refer to the [Stand-alone file](stand-alone.md) section.
 
 :::info
 

--- a/apps/docs/docs/getting-started/installation/package-manager.md
+++ b/apps/docs/docs/getting-started/installation/package-manager.md
@@ -5,7 +5,7 @@ description: This is how I use the library myself
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# npm or yarn
+# Package manager
 
 As with most visual JavaScript libraries there are two sides to the story: getting the JavaScript code in your project, and getting the CSS code. Let's start with JS.
 
@@ -18,9 +18,9 @@ $ npm install --save dropzone
 ```
 </TabItem>
 
-<TabItem value="yarn" label="yarn">
+<TabItem value="pnpm" label="pnpm">
 ```bash
-$ yarn add dropzone
+$ pnpm add dropzone
 ```
 </TabItem>
 </Tabs>
@@ -38,7 +38,7 @@ Without going too much into detail, historically, there have been plenty of ways
 
 Before JavaScript modules there were quite a few other standards. The only other module standard that Dropzone now supports is the [CommonJS format](https://en.wikipedia.org/wiki/CommonJS) which is what node is using too (note that [node also has support for JavaScript modules](https://nodejs.medium.com/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663) now).
 
-We also provide a standalone file that you can simply include in your browser. See the corresponding section for this: [stand-alone.md](stand-alone.md "mention").
+We also provide a standalone file that you can simply include in your browser. See the corresponding section for this: [Stand-alone file](stand-alone.md).
 
 ```javascript
 // If you are using JavaScript/ECMAScript modules:
@@ -69,7 +69,7 @@ Dropzone ships with two files: a `basic.css` and a `dropzone.css`. The `dropzone
 
 Importing this CSS file greatly depends on the bundler or framework that you are using so I won't go into much detail here.
 
-You can also simply include the CSS file in your html. Refer to the [stand-alone.md](stand-alone.md "mention")section for this.
+You can also simply include the CSS file in your html. Refer to the [Stand-alone file](stand-alone.md) section for this.
 
 :::info
 

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -13,7 +13,7 @@ const sidebars = {
           label: "⏬ Installation",
           link: { type: "doc", id: "getting-started/installation/index" },
           items: [
-            "getting-started/installation/npm-or-yarn",
+            "getting-started/installation/package-manager",
             "getting-started/installation/composer",
             "getting-started/installation/stand-alone",
           ],


### PR DESCRIPTION
The repository is a pnpm workspace, so offering yarn as the alternative to npm pointed people at a package manager the project does not itself use. Naming the page after the tools also meant the title had to be revisited every time that set changed, so it is now named after what it covers.

| | was | now |
| --- | --- | --- |
| page | `npm-or-yarn.md` | `package-manager.md` |
| heading | `# npm or yarn` | `# Package manager` |
| tab | `value="yarn" label="yarn"` | `value="pnpm" label="pnpm"` |
| command | `$ yarn add dropzone` | `$ pnpm add dropzone` |

No yarn reference remains anywhere in `apps/docs`, and nothing outside it mentioned yarn at all.

## The links to it were broken prose

They were GitBook import artefacts — the link text was the raw filename, and the closing parenthesis ran straight into the following word, so the installation page rendered as:

> If you are using a package manager please refer to the **npm-or-yarn.md**section.

Renaming the page meant rewriting those links anyway, so they now read as prose. The two links to `stand-alone.md` in the same two files had exactly the same defect and are fixed alongside them. That is all four `"mention"` artefacts in the documentation.

> If you are using a package manager please refer to the **Package manager** section.

## The URL changes

`/getting-started/installation/npm-or-yarn` becomes `/getting-started/installation/package-manager`. This is the cheapest moment it will ever be: the documentation only went live at `www.dropzone.dev/docs` today, so nothing has had time to link to the old path.

Two things follow, both easy to reverse:

- if `docs.dropzone.dev` is ever redirected here path-for-path, this is the single page needing an entry of its own
- if you would rather keep the old URL, adding `slug: /getting-started/installation/npm-or-yarn` to the frontmatter restores it without undoing the rename

## Note

`$ npm install --save dropzone` on the same page is left alone: `--save` has been the default since npm 5 and is merely redundant, which is a separate cleanup.

This no longer stacks on #2356. The two turned out not to conflict, and CI only runs on pull requests targeting `main`, so stacking bought nothing and cost the checks. Both target `main` and can merge in either order.