### PR TITLE
Measure test coverage and report it on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,15 @@ name: CI
 on:
   push:
     branches: [main]
+  # Deliberately not restricted to pull requests targeting main: a stacked
+  # branch opened against its parent would otherwise report no checks at all,
+  # which reads as "nothing failed" rather than "nothing ran".
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
+  # The coverage report is posted as a pull request comment.
+  pull-requests: write
 
 jobs:
   library:
@@ -32,8 +39,21 @@ jobs:
       - run: pnpm format:check
       - run: pnpm lint
       - run: pnpm build:lib
-      - run: pnpm test
+      - run: pnpm test:coverage
       - run: pnpm test:e2e
+
+      # Writes the coverage table into the job summary and, on a pull request,
+      # posts it as a comment. A pull request from a fork only gets a
+      # read-only token, so the comment cannot be posted there and the step is
+      # allowed to fail without failing the build.
+      - name: Report coverage
+        if: always()
+        continue-on-error: true
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          vite-config-path: packages/dropzone/vite.config.mjs
+          json-summary-path: packages/dropzone/coverage/coverage-summary.json
+          json-final-path: packages/dropzone/coverage/coverage-final.json
 
       - name: Upload Playwright report
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __screenshots__
 test-results
 playwright-report
 
+# Vitest coverage
+coverage
+
 # Docusaurus
 .docusaurus
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:website": "pnpm --filter @dropzone/website run dev",
     "dev:docs": "pnpm --filter @dropzone/docs run start",
     "test": "pnpm --filter dropzone run test",
+    "test:coverage": "pnpm --filter dropzone run test:coverage",
     "test:watch": "pnpm --filter dropzone run test:watch",
     "test:e2e": "pnpm --filter dropzone run test:e2e",
     "format": "oxfmt --ignore-path .gitignore --ignore-path .oxfmtignore .",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -47,12 +47,14 @@
     "css": "sass src/:dist/ --style compressed",
     "watch-css": "sass src/:dist/ --watch --style compressed",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@vitest/browser-playwright": "^4.1.11",
+    "@vitest/coverage-v8": "^4.1.11",
     "sass": "^1.33.0",
     "vite": "^8.2.2",
     "vitest": "^4.1.11"

--- a/packages/dropzone/vite.config.mjs
+++ b/packages/dropzone/vite.config.mjs
@@ -39,5 +39,15 @@ export default defineConfig({
       instances: [{ browser: "chromium" }],
       headless: true,
     },
+
+    coverage: {
+      provider: "v8",
+      // Without this, only files a test happened to import are counted, so a
+      // module nothing reaches would quietly improve the percentage by being
+      // absent rather than being reported as uncovered.
+      include: ["src/**/*.js"],
+      reporter: ["text", "html", "json", "json-summary", "lcov"],
+      reportsDirectory: "coverage",
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.11
         version: 4.1.11(playwright@1.62.1)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
       sass:
         specifier: ^1.33.0
         version: 1.103.1
@@ -109,7 +112,7 @@ importers:
         version: 8.3.0(@types/node@26.2.0)(esbuild@0.14.54)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
 
 packages:
 
@@ -781,6 +784,10 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -2394,6 +2401,15 @@ packages:
     peerDependencies:
       vitest: 4.1.11
 
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.11':
     resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
@@ -2589,6 +2605,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.6:
+    resolution: {integrity: sha512-fvpl29helSO2w/z7utIbrkNXILdrLwDwAMH2I/zPKlGf5244+gf+B4cyS1sANcrPY2h+hWCGSgC8N61s/+AF9A==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -4061,6 +4080,18 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4082,6 +4113,9 @@ packages:
 
   joi@17.13.7:
     resolution: {integrity: sha512-MF80Dm5Y2veNy8QWVx9Bj3ui4mo7+VPSPsR1M+oaHXV0Gx6zGX9a2F+OZG3Blby9tOlzU9Rs5FUimlEhbKtfnQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4270,6 +4304,13 @@ packages:
 
   magic-string@1.3.1:
     resolution: {integrity: sha512-rm91zr2Ou+XueDTohjQQjdQEcYM6zVi8KVUCG8Ec3vHwUEKrhSdCNyfuIywkA6hcCAteIn0ZOtAHA6eGpiX+Pg==}
+
+  magicast@0.5.5:
+    resolution: {integrity: sha512-UicdXN8zQ3JHlxVq+28afMXPr1z7WNY6+7EJnzTdQWkTAlMLF5fNCCKxJHBQwGaNGR11581EiQmQzx73+MvszA==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -7381,6 +7422,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@blazediff/core@1.9.1': {}
 
   '@changesets/apply-release-plan@8.0.0':
@@ -9837,7 +9880,7 @@ snapshots:
       '@vitest/mocker': 4.1.11(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -9853,13 +9896,29 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/coverage-v8@4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.11
+      ast-v8-to-istanbul: 1.0.6
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.5
+      obug: 2.2.1
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.11(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))(vitest@4.1.11)
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -10093,6 +10152,12 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -11608,6 +11673,19 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -11641,6 +11719,8 @@ snapshots:
       '@sideway/address': 4.1.5
       '@sideway/formula': 3.0.1
       '@sideway/pinpoint': 2.0.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -11789,6 +11869,16 @@ snapshots:
   magic-string@1.3.1:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.6.0
+
+  magicast@0.5.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   markdown-extensions@2.0.0: {}
 
@@ -14137,7 +14227,7 @@ snapshots:
     optionalDependencies:
       vite: 8.3.0(@types/node@26.2.0)(esbuild@0.14.54)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0)
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))
@@ -14162,6 +14252,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       '@vitest/browser-playwright': 4.1.11(playwright@1.62.1)(vite@8.3.0(@types/node@26.2.0)(jiti@1.21.7)(sass@1.103.1)(terser@5.51.2)(yaml@2.9.0))(vitest@4.1.11)
+      '@vitest/coverage-v8': 4.1.11(@vitest/browser@4.1.11)(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
The suite runs in a real browser, so coverage comes from v8 through the Playwright provider.

## Baseline

| | |
| --- | --- |
| Statements | **72.26%** (839/1161) |
| Branches | **68.70%** (450/655) |
| Functions | **80.47%** (169/210) |
| Lines | **72.20%** (800/1108) |

| file | statements |
| --- | --- |
| `extend.js` | 100% |
| `emitter.js` | 88.57% |
| `options.js` | 75% |
| `dropzone.js` | 70.74% |

Closing those gaps is the next pull request in this stack; this one only makes them visible.

## Two things worth knowing

**`@vitest/coverage-v8` is pinned, not ranged.** Installing it by range resolves to 5.x against `vitest@4.1.11`, and the mismatch does not fail — it reports `0/0` files and a coverage summary of `Unknown%`. Pinned to `4.1.11` to match.

**`coverage.include` is set explicitly** to `src/**/*.js`. By default only files that some test imported are counted, so a module nothing reaches at all would quietly *improve* the percentage by being absent rather than appearing as uncovered.

## CI now runs on every pull request

Previously `pull_request: branches: [main]`. A branch opened against its parent — every stacked pull request after this one — reported *no checks at all*, which reads as "nothing failed" when it actually means "nothing ran". That is the same absence-of-evidence that let a 2023 pull request merge in 2026 with no checks and break `main`.

Coverage is posted as a pull request comment and written to the job summary. Fork pull requests only get a read-only token, so the comment cannot be posted there; that step is allowed to fail without failing the build.

## On the README badge

Left out deliberately. Every option costs more than a few lines *somewhere*:

- **Codecov / Coveralls** — about four lines here plus a badge line, but needs an account enabled against this repository
- **shields.io dynamic badge** — needs a gist and a personal access token stored as a secret
- **a committed badge SVG** — needs CI pushing commits to `main`

If you want one, Codecov is the cheapest and I can add it in a single commit once the repository is enabled there. Until then the coverage table on each pull request carries the same information without a third party.